### PR TITLE
add ffmpeg mod to the list

### DIFF
--- a/mod-list.yml
+++ b/mod-list.yml
@@ -21,3 +21,7 @@ mods:
       - rsync: https://github.com/linuxserver/docker-mods/tree/openssh-server-rsync
       - openssh-client: https://github.com/linuxserver/docker-mods/tree/openssh-server-openssh-client
       - ssh-tunnel: https://github.com/linuxserver/docker-mods/tree/openssh-server-ssh-tunnel
+  lazylibrarian:
+    mod_count: 1
+    container_mods:
+      - ffmpeg: https://github.com/mKeRix/docker-ffmpeg-mod


### PR DESCRIPTION
The mod was created as a response to linuxserver/docker-lazylibrarian#45. As suggested by @CHBMB I'm adding it to the list. If you want to create a new branch in this repo and bring the mod under your control I can also submit a new PR with that.

EDIT: If I should create a new mod I would appreciate it if you could create a new `lazylibrarian-ffmpeg` branch in the repo. :)