### PR TITLE
Fix PATH grep to catch "export PATH" as well as "PATH"

### DIFF
--- a/root/etc/cont-init.d/98-golang
+++ b/root/etc/cont-init.d/98-golang
@@ -1,8 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 echo "ensuring golang is in PATH"
-if grep -q '^PATH=' /etc/services.d/code-server/run; then
-  if ! grep -q '^PATH=.*/usr/local/go/bin.*' /etc/services.d/code-server/run; then
+if grep -q -E '^(export )?PATH=' /etc/services.d/code-server/run; then
+  if ! grep -q -E '^(export )?PATH=.*/usr/local/go/bin.*' /etc/services.d/code-server/run; then
     sed -i '/PATH/ s/$/:\/usr\/local\/go\/bin/' /etc/services.d/code-server/run
   fi
 else


### PR DESCRIPTION
When this mod adds to the PATH it adds it and exports it. The original grep doesn't catch that so it gets added again on container restart. This PR fixes that.