### PR TITLE
code-server-powershell: fix tarball naming, switch to jq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
     - BASEIMAGE="code-server"
     - MODNAME="powershell"
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install jq
+
 jobs:
   include:
     - stage: PR-BuildImage
@@ -26,7 +30,7 @@ jobs:
       if: (NOT (type IN (pull_request)))
       script:
         # Set version
-        - PS_VERSION=$(curl -sX GET "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]' | awk '{print substr($1,2); }')
+        - PS_VERSION=$(curl -sX GET "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" | jq -r .tag_name | awk '{print substr($1,2); }')
         # Build image
         - docker build --no-cache --build-arg PS_VERSION=${PS_VERSION} -t ${DOCKERHUB}:${BASEIMAGE}-${MODNAME}-${PS_VERSION}-${TRAVIS_COMMIT} .
         - docker tag ${DOCKERHUB}:${BASEIMAGE}-${MODNAME}-${PS_VERSION}-${TRAVIS_COMMIT} ${DOCKERHUB}:${BASEIMAGE}-${MODNAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,27 @@ ARG PS_VERSION
 
 RUN \
  apk add --no-cache \
-    curl && \
+    curl \
+    jq && \
  if [ -z ${PS_VERSION+x} ]; then \
 	PS_VERSION=$(curl -sX GET "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]' | awk '{print substr($1,2); }'); \
+	| jq -r .tag_name | awk '{print substr($1,2); }'); \
  fi && \
  mkdir -p /root-layer/powershell && \
  curl -o \
-   /root-layer/powershell/powershell_x86_64.tar.gz -L \
-   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-x64.tar.gz" && \
+    /root-layer/powershell/powershell_x86_64.tar.gz -L \
+    "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-x64.tar.gz" && \
  curl -o \
-   /root-layer/powershell/powershell_armv7l.tar.gz -L \
-   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm32.tar.gz" && \
+    /root-layer/powershell/powershell_armv7l.tar.gz -L \
+    "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm32.tar.gz" && \
  curl -o \
-   /root-layer/powershell/powershell_aarch64.tar.gz -L \
-   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm64.tar.gz"
+    /root-layer/powershell/powershell_aarch64.tar.gz -L \
+    "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm64.tar.gz" && \
+ echo "******** run basic test to validate tarballs *********" && \
+ for i in x86_64 armv7l aarch64; do \
+    mkdir -p "/tmp/${i}"; \
+    tar xzf "/root-layer/powershell/powershell_${i}.tar.gz" -C "/tmp/${i}"; \
+ done
 
 COPY root/ /root-layer/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@ RUN \
  mkdir -p /root-layer/powershell && \
  curl -o \
    /root-layer/powershell/powershell_x86_64.tar.gz -L \
-   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell_${PS_VERSION}-linux-x64.tar.gz" && \
+   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-x64.tar.gz" && \
  curl -o \
    /root-layer/powershell/powershell_armv7l.tar.gz -L \
-   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell_${PS_VERSION}-linux-arm32.tar.gz" && \
+   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm32.tar.gz" && \
  curl -o \
    /root-layer/powershell/powershell_aarch64.tar.gz -L \
-   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell_${PS_VERSION}-linux-arm64.tar.gz"
+   "https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/powershell-${PS_VERSION}-linux-arm64.tar.gz"
 
 COPY root/ /root-layer/
 


### PR DESCRIPTION
Powershell Tarballs dont use underscores in their file names, unlike the distro packages which do.
For example:
Linux x64 TAR: https://github.com/PowerShell/PowerShell/releases/download/v7.0.1/powershell-7.0.1-linux-x64.tar.gz
Debian 10 DEB: https://github.com/PowerShell/PowerShell/releases/download/v7.0.1/powershell_7.0.1-1.debian.10_amd64.deb

EDIT (by maintainer): also switch to jq for initial parsing of api result. With long releases, the github api response formatting is not consistent and awk failed to retrieve the version tag about 50% of the time.