### PR TITLE
linuxserver/mods:letsencrypt-f2bdiscord - Verion lock geoip2

### DIFF
--- a/root/etc/cont-init.d/49-F2BDiscord
+++ b/root/etc/cont-init.d/49-F2BDiscord
@@ -7,7 +7,7 @@ if [ ! -d /usr/lib/python3.8/site-packages/geoip2 ]; then
   pip3 install --no-cache-dir -U \
     requests \
     argparse \
-    geoip2
+    geoip2==3.0.0
 fi
 
 if [ ! -f /config/fail2ban/Fail2Ban.py ]; then


### PR DESCRIPTION
Quick patch to install version 3  of the geoip2 module, to keep the mod working