### PR TITLE
[Swag-cloudflare-realip] Added internet accessibility pre-check and timeouts

### DIFF
--- a/root/etc/cont-init.d/98-cloudflare-real-ip
+++ b/root/etc/cont-init.d/98-cloudflare-real-ip
@@ -2,9 +2,28 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2046
 
+internet_access=0
+retries_left=25
+
+while [[ ${internet_access} -eq 0 ]]; do
+	curl --connect-timeout 5 -I https://www.cloudflare.com/ips-v4 2> /dev/null
+	
+	rc=$?
+	
+	if [[ ${rc} -eq 0 ]]; then
+		internet_access=1
+	fi
+
+	if [[ ${retries_left} -eq 0 ]]; then
+		internet_access=2
+	fi
+
+	retries_left=$(( ${retries_left} - 1 ))
+done
+
 printf "set_real_ip_from %b;\n" $({
-  curl -s "https://www.cloudflare.com/ips-v4" &
-  curl -s "https://www.cloudflare.com/ips-v6" &
+  curl --connect-timeout 5 -s "https://www.cloudflare.com/ips-v4" &
+  curl --connect-timeout 5 -s "https://www.cloudflare.com/ips-v6" &
   ip route | grep -v default | awk '{print $1}'
 }) > /config/nginx/cf_real-ip.conf
 

--- a/root/etc/cont-init.d/98-cloudflare-real-ip
+++ b/root/etc/cont-init.d/98-cloudflare-real-ip
@@ -2,29 +2,20 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2046
 
-internet_access=0
-retries_left=25
+conf_file="/config/nginx/cf_real-ip.conf"
 
-while [[ ${internet_access} -eq 0 ]]; do
-	curl --connect-timeout 5 -I https://www.cloudflare.com/ips-v4 2> /dev/null
-	
-	rc=$?
-	
-	if [[ ${rc} -eq 0 ]]; then
-		internet_access=1
-	fi
+curl --connect-timeout 5 --max-time 5 --retry 3 --retry-delay 0 --retry-max-time 20 https://www.cloudflare.com/ips-v4 &> /dev/null
 
-	if [[ ${retries_left} -eq 0 ]]; then
-		internet_access=2
-	fi
+rc=$?
 
-	retries_left=$(( ${retries_left} - 1 ))
-done
+if [[ ${rc} -eq 0 ]]; then
+	printf "set_real_ip_from %b;\n" $({
+		curl -s "https://www.cloudflare.com/ips-v4" &
+		curl -s "https://www.cloudflare.com/ips-v6" &
+		ip route | grep -v default | awk '{print $1}'
+	}) > ${conf_file}
+elif [ ! -f ${conf_file} ]; then
+	printf "set_real_ip_from %b;\n" $(ip route | grep -v default | awk '{print $1}') > ${conf_file}
+fi
 
-printf "set_real_ip_from %b;\n" $({
-  curl --connect-timeout 5 -s "https://www.cloudflare.com/ips-v4" &
-  curl --connect-timeout 5 -s "https://www.cloudflare.com/ips-v6" &
-  ip route | grep -v default | awk '{print $1}'
-}) > /config/nginx/cf_real-ip.conf
-
-chown abc:abc /config/nginx/cf_real-ip.conf
+chown abc:abc ${conf_file}


### PR DESCRIPTION
### Edits
- Perform a pre-check to make sure the internet (Cloudflare specifically) is accessible
- Added a reasonable retry count of 25 before the script will fail out
- Added connection timeouts to help with smoother curl failures

### Reasoning
After talking with https://github.com/rg9400, in relation to his issue https://github.com/linuxserver/docker-mods/issues/164, I've added an internet accessibility pre-check allowing up to 25 retries before it fails out. Also, I've added a connection timeout to the curl commands to make the failure rate smoother after 5s if the connection to Cloudflare couldn't be made.

### Use Case
In RG's case, even though he has it set up where Swag will execute after AdGuardHome is active, AGH still has an initialization process and causing this docker-mod to fail as there isn't an active internet connection at the time.