### PR TITLE
Upgrade code-server-php to 8.0

### DIFF
--- a/root/etc/cont-init.d/98-php
+++ b/root/etc/cont-init.d/98-php
@@ -5,7 +5,7 @@ apt-get update && apt-get install -y \
   software-properties-common
 ppa="ppa:ondrej/php"
 if ! grep -q "^deb .*${ppa}" /etc/apt/sources.list /etc/apt/sources.list.d/*; then
-    add-apt-repository ${ppa}
+    add-apt-repository ${ppa} -y
 fi
 
 echo "**** installing php and composer ****"

--- a/root/etc/cont-init.d/98-php
+++ b/root/etc/cont-init.d/98-php
@@ -1,6 +1,14 @@
 #!/usr/bin/with-contenv bash
 
+echo "**** adding ppa ondrej/php ****"
+apt-get update && apt-get install -y \
+  software-properties-common
+ppa="ppa:ondrej/php"
+if ! grep -q "^deb .*${ppa}" /etc/apt/sources.list /etc/apt/sources.list.d/*; then
+    add-apt-repository ${ppa}
+fi
+
 echo "**** installing php and composer ****"
 apt-get update && apt-get install -y \
   composer \
-  php7.2
+  php8.0


### PR DESCRIPTION
PHP 8.0 version bump using ondrej/php PPA ([issue 176](https://github.com/linuxserver/docker-mods/issues/176))

Available on `wielewout/code-server-mods:php8.0` for testing.