### PR TITLE
Code server golang: install GCC as well because gopls depends on it

### DIFF
--- a/root/etc/cont-init.d/98-golang
+++ b/root/etc/cont-init.d/98-golang
@@ -17,6 +17,9 @@ if [ -f "/golang/golang_${ARCH}.tar.gz" ]; then
   echo "Installing golang"
   tar xzf "/golang/golang_${ARCH}.tar.gz" -C /usr/local
   rm -rf /golang
+
+  echo "Installing gcc, to make CGO work"
+  apt-get update && apt-get install -y gcc
 else
   echo "Golang already installed, skipping"
 fi


### PR DESCRIPTION
Thanks for the great mod!!

After installing this and start using code-server, the first natural step would be installing the VS Code Go extension, then it will prompt to install gopls.

But you will see an error like this:
```
Installing golang.org/x/tools/gopls FAILED
{
 "killed": false,
 "code": 2,
 "signal": null,
 "cmd": "/usr/local/go/bin/go get -v golang.org/x/tools/gopls",
 "stdout": "",
 "stderr": "go: downloading golang.org/x/tools v0.1.0\ngo: downloading golang.org/x/tools/gopls v0.6.6\ngo: downloading golang.org/x/tools v0.1.1-0.20210222172741-77e031214674\ngo: downloading github.com/sergi/go-diff v1.1.0\ngo: downloading honnef.co/go/tools v0.1.1\ngo: downloading mvdan.cc/gofumpt v0.1.0\ngo: downloading mvdan.cc/xurls/v2 v2.2.0\ngo: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1\ngo: downloading golang.org/x/mod v0.4.1\ngo: downloading github.com/google/go-cmp v0.5.4\ngo: downloading golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c\ngo: downloading golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9\ngo: downloading github.com/BurntSushi/toml v0.3.1\ngolang.org/x/mod/semver\ngolang.org/x/xerrors/internal\nhonnef.co/go/tools/knowledge\nruntime/cgo\n# runtime/cgo\ncgo: exec gcc: exec: \"gcc\": executable file not found in $PATH\ngithub.com/google/go-cmp/cmp/internal/flags\ngolang.org/x/tools/internal/xcontext\nhonnef.co/go/tools/printf\ngithub.com/sergi/go-diff/diffmatchpatch\ngolang.org/x/tools/go/ast/astutil\ngolang.org/x/tools/internal/lsp/fuzzy\ngolang.org/x/tools/internal/span\ngolang.org/x/mod/internal/lazyregexp\ngolang.org/x/xerrors\ngolang.org/x/tools/internal/lsp/diff\ngolang.org/x/tools/go/analysis/passes/internal/analysisutil\ngolang.org/x/tools/internal/analysisinternal\ngolang.org/x/mod/module\ngolang.org/x/tools/go/ast/inspector\ngolang.org/x/tools/go/types/typeutil\ngolang.org/x/tools/go/cfg\ngolang.org/x/mod/modfile\ngolang.org/x/tools/go/analysis\ngolang.org/x/tools/internal/event/label\ngolang.org/x/tools/internal/event/keys\ngolang.org/x/tools/go/analysis/passes/asmdecl\ngolang.org/x/tools/go/analysis/passes/inspect\ngolang.org/x/tools/go/analysis/passes/assign\ngolang.org/x/tools/go/analysis/passes/atomic\ngolang.org/x/tools/go/analysis/passes/atomicalign\ngolang.org/x/tools/go/analysis/passes/bools\ngolang.org/x/tools/go/analysis/passes/buildtag\ngolang.org/x/tools/go/analysis/passes/cgocall\ngolang.org/x/tools/go/analysis/passes/composite\ngolang.org/x/tools/go/analysis/passes/copylock\ngolang.org/x/tools/go/analysis/passes/deepequalerrors\ngolang.org/x/tools/go/analysis/passes/errorsas\ngolang.org/x/tools/go/analysis/passes/fieldalignment\ngolang.org/x/tools/go/analysis/passes/httpresponse\ngolang.org/x/tools/go/analysis/passes/ifaceassert\ngolang.org/x/tools/go/analysis/passes/loopclosure\ngolang.org/x/tools/go/analysis/passes/ctrlflow\ngolang.org/x/tools/go/analysis/passes/nilfunc\ngolang.org/x/tools/go/analysis/passes/printf\ngolang.org/x/tools/go/analysis/passes/shadow\ngolang.org/x/tools/go/analysis/passes/shift\ngolang.org/x/tools/go/analysis/passes/lostcancel\ngolang.org/x/tools/go/analysis/passes/sortslice\ngolang.org/x/tools/go/analysis/passes/stdmethods\ngolang.org/x/tools/go/analysis/passes/stringintconv\ngolang.org/x/tools/go/analysis/passes/structtag\ngolang.org/x/tools/go/analysis/passes/testinggoroutine\ngolang.org/x/tools/go/analysis/passes/tests\ngolang.org/x/tools/go/analysis/passes/unmarshal\ngolang.org/x/tools/go/analysis/passes/unreachable\ngolang.org/x/tools/go/analysis/passes/unsafeptr\ngolang.org/x/tools/go/analysis/passes/unusedresult\ngolang.org/x/tools/internal/event/core\ngolang.org/x/sys/execabs\ngolang.org/x/tools/internal/fastwalk\ngolang.org/x/tools/internal/lsp/analysis/fillreturns\ngolang.org/x/tools/internal/lsp/analysis/fillstruct\ngolang.org/x/tools/internal/event\ngolang.org/x/tools/internal/gopathwalk\ngolang.org/x/tools/internal/gocommand\ngolang.org/x/tools/internal/lsp/analysis/nonewvars\ngolang.org/x/tools/internal/lsp/analysis/noresultvalues\ngolang.org/x/tools/internal/lsp/analysis/simplifycompositelit\ngolang.org/x/tools/internal/lsp/analysis/simplifyrange\ngolang.org/x/tools/internal/lsp/analysis/simplifyslice\ngolang.org/x/tools/internal/lsp/analysis/undeclaredname\ngolang.org/x/tools/internal/imports\ngolang.org/x/tools/internal/lsp/analysis/unusedparams\ngolang.org/x/tools/internal/event/export\ngolang.org/x/tools/internal/lsp/debug/tag\ngolang.org/x/tools/internal/lsp/diff/myers\ngolang.org/x/tools/refactor/satisfy\nhonnef.co/go/tools/analysis/lint\nhonnef.co/go/tools/go/ir\ngolang.org/x/tools/go/buildutil\ngolang.org/x/tools/go/internal/cgo\ngolang.org/x/tools/go/internal/gcimporter\ngolang.org/x/tools/go/loader\ngolang.org/x/tools/go/internal/packagesdriver\ngolang.org/x/tools/internal/packagesinternal\ngolang.org/x/tools/internal/typesinternal\nhonnef.co/go/tools/go/types/typeutil\nhonnef.co/go/tools/pattern\nhonnef.co/go/tools/go/ast/astutil\ngolang.org/x/tools/go/gcexportdata\ngolang.org/x/tools/go/packages\ngithub.com/BurntSushi/toml\ngithub.com/google/go-cmp/cmp/internal/diff\nhonnef.co/go/tools/config\ngithub.com/google/go-cmp/cmp/internal/function\ngithub.com/google/go-cmp/cmp/internal/value\nmvdan.cc/xurls/v2\ngolang.org/x/sync/errgroup\ngithub.com/google/go-cmp/cmp\nhonnef.co/go/tools/analysis/edit\ngolang.org/x/tools/internal/lsp/debug/log\ngolang.org/x/tools/internal/memoize\nhonnef.co/go/tools/go/ir/irutil\nhonnef.co/go/tools/internal/passes/buildir\ngolang.org/x/tools/internal/event/export/metric\nhonnef.co/go/tools/analysis/facts/nilness\ngolang.org/x/tools/internal/event/export/ocagent/wire\nhonnef.co/go/tools/analysis/facts\nhonnef.co/go/tools/internal/sharedcheck\nhonnef.co/go/tools/analysis/facts/typedness\ngolang.org/x/tools/internal/lsp/snippet\ngolang.org/x/tools/internal/lsp/browser\ngolang.org/x/tools/internal/tool\nhonnef.co/go/tools/analysis/code\nhonnef.co/go/tools/analysis/report\nmvdan.cc/gofumpt/format\nhonnef.co/go/tools/stylecheck\nhonnef.co/go/tools/simple\n"
}

1 tools failed to install.

gopls: failed to install gopls(golang.org/x/tools/gopls): Error: Command failed: /usr/local/go/bin/go get -v golang.org/x/tools/gopls
go: downloading golang.org/x/tools v0.1.0
go: downloading golang.org/x/tools/gopls v0.6.6
go: downloading golang.org/x/tools v0.1.1-0.20210222172741-77e031214674
go: downloading github.com/sergi/go-diff v1.1.0
go: downloading honnef.co/go/tools v0.1.1
go: downloading mvdan.cc/gofumpt v0.1.0
go: downloading mvdan.cc/xurls/v2 v2.2.0
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/mod v0.4.1
go: downloading github.com/google/go-cmp v0.5.4
go: downloading golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
go: downloading golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
go: downloading github.com/BurntSushi/toml v0.3.1
golang.org/x/mod/semver
golang.org/x/xerrors/internal
honnef.co/go/tools/knowledge
runtime/cgo
# runtime/cgo
cgo: exec gcc: exec: "gcc": executable file not found in $PATH
```

With this patch, the mod will install gcc so gopls could be installed right away.

Tested by starting a clean container and apply the mod from [caiych/mod](https://hub.docker.com/repository/docker/caiych/mods).

```
Tools environment: GOPATH=/config/go
Installing 1 tool at /config/go/bin in module mode.
  gopls

Installing golang.org/x/tools/gopls (/config/go/bin/gopls) SUCCEEDED

All tools successfully installed. You are ready to Go :).
```