### PR TITLE
standardize apt-get

### DIFF
--- a/root/etc/cont-init.d/95-apt-get
+++ b/root/etc/cont-init.d/95-apt-get
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bash
+
+apt-get update

--- a/root/etc/cont-init.d/98-php
+++ b/root/etc/cont-init.d/98-php
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
 echo "**** installing php and composer ****"
-apt-get update && apt-get install -y \
-  composer \
-  php7.2
+apt-get install -y \
+    composer \
+    php7.2

--- a/root/etc/cont-init.d/98-php
+++ b/root/etc/cont-init.d/98-php
@@ -3,4 +3,4 @@
 echo "**** installing php and composer ****"
 apt-get install -y \
     composer \
-    php7.2
+    php


### PR DESCRIPTION
also switch to installing non-specific php version so it won't break when moving to focal