### PR TITLE
Update 98-cloudflare-real-ip

### DIFF
--- a/root/etc/cont-init.d/98-cloudflare-real-ip
+++ b/root/etc/cont-init.d/98-cloudflare-real-ip
@@ -3,8 +3,8 @@
 # shellcheck disable=SC2046
 
 printf "set_real_ip_from %b;\n" $({
-  curl -s "https://www.cloudflare.com/ips-v4" &
-  curl -s "https://www.cloudflare.com/ips-v6" &
+  curl -s -w '\n' "https://www.cloudflare.com/ips-v4" &
+  curl -s -w '\n' "https://www.cloudflare.com/ips-v6" &
   ip route | grep -v default | awk '{print $1}'
 }) > /config/nginx/cf_real-ip.conf
 


### PR DESCRIPTION
## Error in swag logs
```
nginx: [emerg] host not found in set_real_ip_from "131.0.72.0/222400:cb00::/32" in /config/nginx/cf_real-ip.conf:16
```
Content of `/config/nginx/cf_real-ip.conf`
```
set_real_ip_from 172.18.0.0/16;
set_real_ip_from 173.245.48.0/20;
set_real_ip_from 103.21.244.0/22;
set_real_ip_from 103.22.200.0/22;
set_real_ip_from 103.31.4.0/22;
set_real_ip_from 141.101.64.0/18;
set_real_ip_from 108.162.192.0/18;
set_real_ip_from 190.93.240.0/20;
set_real_ip_from 188.114.96.0/20;
set_real_ip_from 197.234.240.0/22;
set_real_ip_from 198.41.128.0/17;
set_real_ip_from 162.158.0.0/15;
set_real_ip_from 104.16.0.0/13;
set_real_ip_from 104.24.0.0/14;
set_real_ip_from 172.64.0.0/13;
set_real_ip_from 131.0.72.0/222400:cb00::/32;
set_real_ip_from 2606:4700::/32;
set_real_ip_from 2803:f800::/32;
set_real_ip_from 2405:b500::/32;
set_real_ip_from 2405:8100::/32;
set_real_ip_from 2a06:98c0::/29;
set_real_ip_from 2c0f:f248::/32;
```

## Issue
The last line of the response from Cloudflare has a "procent sign" instead of a new line. This causes one line from the ip4 list to mix with the ip6 list which in turn causes nginx to fail parsing `/config/nginx/cf_real-ip.conf`.


## Solution
Print new line instead of a `%` at the end of the last line

### Example

```sh
[user@local ~]$ curl -s "https://www.cloudflare.com/ips-v4" &&  curl -s "https://www.cloudflare.com/ips-v6"
173.245.48.0/20
103.21.244.0/22
103.22.200.0/22
103.31.4.0/22
141.101.64.0/18
108.162.192.0/18
190.93.240.0/20
188.114.96.0/20
197.234.240.0/22
198.41.128.0/17
162.158.0.0/15
104.16.0.0/13
104.24.0.0/14
172.64.0.0/13
131.0.72.0/222400:cb00::/32
2606:4700::/32
2803:f800::/32
2405:b500::/32
2405:8100::/32
2a06:98c0::/29
2c0f:f248::/32[user@local ~]$
```

### Suggested solution

Adding argument for new line with flag `-w`

```sh
[user@local ~]$ curl -s -w "\n" "https://www.cloudflare.com/ips-v4" &&  curl -s -w "\n" "https://www.cloudflare.com/ips-v6"
173.245.48.0/20
103.21.244.0/22
103.22.200.0/22
103.31.4.0/22
141.101.64.0/18
108.162.192.0/18
190.93.240.0/20
188.114.96.0/20
197.234.240.0/22
198.41.128.0/17
162.158.0.0/15
104.16.0.0/13
104.24.0.0/14
172.64.0.0/13
131.0.72.0/22
2400:cb00::/32
2606:4700::/32
2803:f800::/32
2405:b500::/32
2405:8100::/32
2a06:98c0::/29
2c0f:f248::/32
[user@local ~]$
```

