### PR TITLE
cloudflared: fix for new API responses, json nested under .results and .errors

### DIFF
--- a/root/etc/cont-init.d/98-cloudflared-config
+++ b/root/etc/cont-init.d/98-cloudflared-config
@@ -87,7 +87,7 @@ if [[ ${#CF_ACCOUNT_ID} -gt 0 ]] && [[ ${#CF_API_TOKEN} -gt 0 ]] && [[ ${#CF_TUN
         --data "{\"name\":\"${CF_TUNNEL_NAME}\",\"tunnel_secret\":\"${CF_TUNNEL_SECRET}\"}")
     echo ${JSON_RESULT} | jq
 
-    JSON_CODE_VALUE=$(echo ${JSON_RESULT} | jq -rc ".code")
+    JSON_CODE_VALUE=$(echo ${JSON_RESULT} | jq -rc ".errors[].code")
     if [[ ${JSON_CODE_VALUE} -eq 1013 ]]; then
       echo "**** You already have a cloudflare tunnel named ${CF_TUNNEL_NAME} ****"
     
@@ -99,24 +99,27 @@ if [[ ${#CF_ACCOUNT_ID} -gt 0 ]] && [[ ${#CF_API_TOKEN} -gt 0 ]] && [[ ${#CF_TUN
       echo ${JSON_RESULT} | jq
 
       echo "**** Fetching existing cloudflare tunnel(${CF_TUNNEL_NAME}) via API... ****"
-      CF_TUNNEL_ID=$(echo ${JSON_RESULT} | jq -rc ".[].id")
+      CF_TUNNEL_ID=$(echo ${JSON_RESULT} | jq -rc ".result[].id")
       JSON_RESULT=$(curl -sX \
         GET "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/tunnels/${CF_TUNNEL_ID}?" \
           -H "Authorization: Bearer ${CF_API_TOKEN}" \
           -H "Content-Type: application/json")
 
-      JSON_RESULT=$(echo ${JSON_RESULT} | jq -rc ". + {\"credentials_file\": {\"AccountTag\": \"${CF_ACCOUNT_ID}\",\"TunnelID\": \"${CF_TUNNEL_ID}\",\"TunnelName\": \"${CF_TUNNEL_NAME}\",\"TunnelSecret\": \"${CF_TUNNEL_SECRET}\"}}")
+      JSON_RESULT=$(echo ${JSON_RESULT} | jq -rc ". |= .+ {\"credentials_file\": {\"AccountTag\": \"${CF_ACCOUNT_ID}\",\"TunnelID\": \"${CF_TUNNEL_ID}\",\"TunnelName\": \"${CF_TUNNEL_NAME}\",\"TunnelSecret\": \"${CF_TUNNEL_SECRET}\"}}")
       echo ${JSON_RESULT} | jq
     fi
 
-    CF_TUNNEL_ID=$(echo ${JSON_RESULT} | jq -rc ".id")
+    CF_TUNNEL_ID=$(echo ${JSON_RESULT} | jq -rc ".result.id")
     CREDENTIALS_FILE=$(echo ${JSON_RESULT} | jq -rc ".credentials_file")
+    if [ $CREDENTIALS_FILE = "null" ]; then # when created through POST, credentials_file is part of .results (maybe incomplete json response), check where it is
+      CREDENTIALS_FILE=$(echo ${JSON_RESULT} | jq -rc ".result.credentials_file")
+    fi
     echo "**** Saving cloudflare tunnel(${CF_TUNNEL_NAME}) credentials json... ****"
     if [ ! -d "/etc/cloudflared/" ]; then
       mkdir -p "/etc/cloudflared";
     fi
     printf "${CREDENTIALS_FILE}" > "/etc/cloudflared/${CF_TUNNEL_ID}.json"
-    echo ${JSON_RESULT} | jq -r ".credentials_file"
+    echo ${JSON_RESULT} | jq -r ".result.credentials_file"
     echo "**** Cloudflare tunnel(${CF_TUNNEL_NAME}) credentials saved to /etc/cloudflared/${CF_TUNNEL_ID}.json ****"
 
     echo "**** Generating config.yml for cloudflare tunnel(${CF_TUNNEL_NAME})... ****"


### PR DESCRIPTION
Latest deployments are failing on `null` values in `CF_TUNNEL_ID` , `CREDENTIALS_FILE` and configuration files being rendered useless, containing only `null` value.

Logs:
```
 [cont-init.d] 98-cloudflared-config: executing... 
 **** Cloudflared setup script init... ****
 **** Checking cloudflared setup script requirements... ****
 **** Linux architecture found: amd64 ****
 **** Linux distro found: alpine ****
 **** Checking for cloudflared setup script dependencies... ****
 **** Temporarily installing /tmp/yq... ****
 **** jq already installed, skipping... ****
 **** curl already installed, skipping... ****
 **** Installing cloudflared...****
 **** Moving /cloudflared/cloudflared-amd64 to /usr/local/bin/cloudflared... ****
 **** Deleting tmp /cloudflared dir... ****
 **** Cloudflared installed ****
 cloudflared version 2021.10.5 (built 2021-10-25-2039 UTC)
 **** Checking for optional cloudflare tunnel parameters... ****
 **** Cloudflare tunnel parameters found, starting cloudflare tunnel setup... ****
 **** Creating cloudflare tunnel(nginx) via API... ****
 {
   "success": true,
   "messages": [],
   "errors": [],
   "result": {
     "id": "xxxxxxx-zzzzzz-yyyy-a8a7-xxxxxxxxxxx",
     "account_tag": "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "created_at": "2021-11-01T04:21:51.464282Z",
     "deleted_at": null,
     "name": "nginx",
     "connections": [],
     "conns_active_at": null,
     "conns_inactive_at": "2021-11-01T04:21:51.464282Z",
     "tun_type": "cfd_tunnel",
     "metadata": {},
     "status": "inactive",
     "credentials_file": {
       "AccountTag": "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "TunnelID": "xxxxxxx-zzzzzz-yyyy-a8a7-xxxxxxxxxxx",
       "TunnelName": "nginx",
       "TunnelSecret": "WjRSaEU2YU40ODdCWFVEZFp5QThtcFFuaGh4QzlNWUsjb3B0aW9uYWwK"
     }
   }
 }
 **** Saving cloudflare tunnel(nginx) credentials json... ****
 null
 **** Cloudflare tunnel(nginx) credentials saved to /etc/cloudflared/null.json ****
 **** Generating config.yml for cloudflare tunnel(nginx)... ****
 tunnel: null
 credentials-file: /etc/cloudflared/null.json
 no-autoupdate: true
 ingress:
   - hostname: nginx.example.com
     service: hello_world
   - service: http_status:404
 **** Config for cloudflare tunnel(nginx) saved to /etc/cloudflared/config.yml ****
 **** Validating cloudflared tunnel rules... ****
 Validating rules from /etc/cloudflared/config.yml
 OK
 **** Updating cloudflare zone... ****
 **** Searching zone for hostname(nginx.example.com) via API... ****
 **** Updating existing CNAME for hostname(nginx.example.com) via API... ****
 {
   "result": {
     "id": "d133c8eafff1e2bddff702311e39d0f6",
     "zone_id": "00e22252e091dcaa6b10d98251ff76a6",
     "zone_name": "example.com",
     "name": "nginx.example.com",
     "type": "CNAME",
     "content": "null.cfargotunnel.com",
     "proxiable": true,
     "proxied": true,
     "ttl": 1,
     "locked": false,
     "meta": {
       "auto_added": false,
       "managed_by_apps": false,
       "managed_by_argo_tunnel": false
     },
     "created_on": "2021-11-01T02:25:48.507188Z",
     "modified_on": "2021-11-01T04:16:41.696773Z"
   },
   "success": true,
   "errors": [],
   "messages": []
 }
 **** Cleaning up cloudflared setup script dependencies if required... ****
 **** Uninstalling /tmp/yq... ****
 **** Cloudflared setup script done, exiting... ****
 [cont-init.d] 98-cloudflared-config: exited 0.
 [cont-init.d] 99-custom-files: executing... 
 [custom-init] no custom files found exiting...
 [cont-init.d] 99-custom-files: exited 0.
 [cont-init.d] done.
 [services.d] starting services
 [services.d] done.
 "cloudflared tunnel run" requires the ID or name of the tunnel to run as the last command line argument or in the configuration file.
```

Content of the files:

```
docker exec -ti nginx bash
root@548657ff7c7c:/# cd /etc/cloudflared/
root@548657ff7c7c:/etc/cloudflared# ls -la 
total 16
drwxr-xr-x 1 abc  users   38 Nov  1 04:16 .
drwxr-xr-x 1 root root  4096 Nov  1 04:16 ..
-rw-r--r-- 1 root root   174 Nov  1 04:16 config.yml
-rw-r--r-- 1 root root     4 Nov  1 04:16 null.json
root@548657ff7c7c:/etc/cloudflared# cat config.yml 
tunnel: null
credentials-file: /etc/cloudflared/null.json
no-autoupdate: true

ingress:
  - hostname: nginx.example.com
    service: hello_world
  - service: http_status:404
root@548657ff7c7c:/etc/cloudflared# cat null.json 
nullroot@548657ff7c7c:/etc/cloudflared# 
``` 