### PR TITLE
Removed trailing double colons from docker commands

### DIFF
--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Tag image
         if: ${{ github.ref == format('refs/heads/{0}', env.BRANCH) }}
         run: |
-          docker tag ${{ github.sha }} ${ENDPOINT}:
+          docker tag ${{ github.sha }} ${ENDPOINT}
           docker tag ${{ github.sha }} ${ENDPOINT}:${{ github.sha }}
-          docker tag ${{ github.sha }} ghcr.io/${ENDPOINT}:
+          docker tag ${{ github.sha }} ghcr.io/${ENDPOINT}
           docker tag ${{ github.sha }} ghcr.io/${ENDPOINT}:${{ github.sha }}
 
       - name: Credential check
@@ -47,7 +47,7 @@ jobs:
         if: ${{ github.ref == format('refs/heads/{0}', env.BRANCH) && env.CR_USER && env.CR_PAT }}
         run: |
           docker push ghcr.io/${ENDPOINT}:${{ github.sha }}
-          docker push ghcr.io/${ENDPOINT}:
+          docker push ghcr.io/${ENDPOINT}
 
       - name: Login to DockerHub
         if: ${{ github.ref == format('refs/heads/{0}', env.BRANCH) && env.DOCKERUSER && env.DOCKERPASS }}
@@ -58,4 +58,4 @@ jobs:
         if: ${{ github.ref == format('refs/heads/{0}', env.BRANCH) && env.DOCKERUSER && env.DOCKERPASS }}
         run: |
           docker push ${ENDPOINT}:${{ github.sha }}
-          docker push ${ENDPOINT}:
+          docker push ${ENDPOINT}


### PR DESCRIPTION
The trailing double colons should be removed from the docker commands as the commands fail otherwise as mentioned in issue #255.