### PR TITLE
Fix the availability check on apps with basic auth

### DIFF
--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -34,7 +34,6 @@ def find_apps():
 def is_available(url):
     try:
         host, port = url.split("/")[2].split(":")
-        print(host + port)
         with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             if sock.connect_ex((host, int(port))) == 0:
                 return True

--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -1,10 +1,11 @@
 import collections
+import contextlib
 import concurrent.futures
 import glob
 import json
 import os
 import re
-import requests
+import socket
 import urllib3
 
 
@@ -32,10 +33,16 @@ def find_apps():
 
 def is_available(url):
     try:
-        requests.head(url, timeout=5, verify=False)
-        return True
+        host, port = url.split("/")[2].split(":")
+        print(host + port)
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            if sock.connect_ex((host, int(port))) == 0:
+                return True
+            else:
+                return False
     except:
-        return False
+        return False    
+
 
 urllib3.disable_warnings()
 apps = find_apps()


### PR DESCRIPTION
Some containers like nzbget have basic auth which needs a different approach for the availability check.