### PR TITLE
Using `lt` instead of `le to check length of tunnel password

### DIFF
--- a/root/etc/cont-init.d/98-cloudflared-config
+++ b/root/etc/cont-init.d/98-cloudflared-config
@@ -72,7 +72,7 @@ cloudflared -v
 
 echo "**** Checking for optional cloudflare tunnel parameters... ****"
 if [[ ${#CF_ACCOUNT_ID} -gt 0 ]] && [[ ${#CF_API_TOKEN} -gt 0 ]] && [[ ${#CF_TUNNEL_NAME} -gt 0 ]]; then
-  if [[ ${#CF_TUNNEL_PASSWORD} -le 32 ]]; then
+  if [[ ${#CF_TUNNEL_PASSWORD} -lt 32 ]]; then
     echo "**** Cloudflare tunnel password must be at least 32 characters long, exiting... ****"
     exit 1 
   else


### PR DESCRIPTION
fixes #307 in the case where one uses a 32 char long tunnel password.