### PR TITLE
Code server extension arguments compatibility update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,22 @@
 
 This mod installs code-server extensions at startup. The list of extensions to be installed should be provided using environment variable `VSCODE_EXTENSION_IDS` separated by `|`.
 
+__NOTE__:
+Since transitioning from `v3.12.0` to `v4.0.x` `code-server` has been forced to use a new Extensions Gallery / Marketplace. This results in a smaller set of plugins being available to install. Please take this into account before opening an Issue! 
+
+A workaround for this is to use the environment variable `EXTENSIONS_GALLERY` to provide a different marketplace URL. The commandline installer used by this plugin will also use the marketplace provided by this variable.
+
+Please refer to the [code-server FAQ](https://github.com/coder/code-server/blob/main/docs/FAQ.md#how-do-i-use-my-own-extensions-marketplace) for additional information.
+
+
 For example, to install the `vscode-docker` and `vscode-icons` extensions add the following lines to your docker compose service:
 ```yaml
-- DOCKER_MODS=linuxserver/mods:code-server-docker|linuxserver/mods:code-server-extension-arguments
-- VSCODE_EXTENSION_IDS=vscode-icons-team.vscode-icons|ms-azuretools.vscode-docker
+vscode:
+  image: linuxserver/code-server
+  environment:
+    DOCKER_MODS: 'linuxserver/mods:code-server-docker|linuxserver/mods:code-server-extension-arguments'
+    VSCODE_EXTENSION_IDS: 'vscode-icons-team.vscode-icons|ms-azuretools.vscode-docker'
+    ## Optionally use a different marketplace if required extensions are unavailable. e.g.:
+    # EXTENSIONS_GALLERY: '{"serviceUrl": "https://extensions.coder.com/api"}'
+    # EXTENSIONS_GALLERY: '{"serviceUrl": "https://open-vsx.org/vscode/gallery", "itemUrl": "https://open-vsx.org/vscode/item"}'
 ```

--- a/root/etc/cont-init.d/99-install-extensions
+++ b/root/etc/cont-init.d/99-install-extensions
@@ -11,5 +11,5 @@ IFS='|'
 VSCODE_EXTENSION_IDS=(${VSCODE_EXTENSION_IDS})
 for ID in "${VSCODE_EXTENSION_IDS[@]}"; do
     echo "**** installing extension: ${ID} ****"
-    s6-setuidgid abc code-server --user-data-dir /config/data --extensions-dir /config/extensions --install-extension ${ID}
+    install-extension ${ID}
 done

--- a/root/etc/cont-init.d/99-install-extensions
+++ b/root/etc/cont-init.d/99-install-extensions
@@ -9,7 +9,15 @@ fi
 
 IFS='|'
 VSCODE_EXTENSION_IDS=(${VSCODE_EXTENSION_IDS})
-for ID in "${VSCODE_EXTENSION_IDS[@]}"; do
-    echo "**** installing extension: ${ID} ****"
-    install-extension ${ID}
-done
+
+# Use newly available abstraction if available (>= v4.0.x), else fallback to old method.
+if [ -x "$(command -v install-extension)" ]; then
+    for ID in "${VSCODE_EXTENSION_IDS[@]}"; do
+        install-extension ${ID}
+    done
+else
+    for ID in "${VSCODE_EXTENSION_IDS[@]}"; do
+        s6-setuidgid abc code-server --user-data-dir /config/data --extensions-dir /config/extensions --install-extension ${ID}
+    done
+fi
+


### PR DESCRIPTION
Added information to the Readme file, related to the v3.12 to v4.x update.

Modified installation script to use the `install-extension` abstraction if present. Fallback to old installation method for pre v4.x images. (This keeps the plugin usefull for older images, which comes in handy since a lot of plugins don't seem to be yet available on v4)