### PR TITLE
Handle missing http.d include

### DIFF
--- a/root/etc/cont-init.d/98-crowdsec
+++ b/root/etc/cont-init.d/98-crowdsec
@@ -63,14 +63,14 @@ if ! grep -q '[^#]include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'
     else
         # Warn about missing http.d include
         echo "
-        ***************************************************************
-        *    Warning: Your nginx.conf is missing required settings    *
-        *    Please add:                                              *
-        *        include /etc/nginx/http.d/*.conf;                    *
-        *    to the http{} block and restart the container.           *
-        *                                                             *
-        *    The bouncer will not function until this is done.        *
-        ***************************************************************"
+        ********************************************************************
+        *    Warning: Your nginx.conf is missing required settings         *
+        *    Please add:                                                   *
+        *        include /etc/nginx/http.d/*.conf;                         *
+        *    to the http{} block and restart the container.                *
+        *                                                                  *
+        *    The CrowdSec bouncer will not function until this is done.    *
+        ********************************************************************"
     fi
 fi
 

--- a/root/etc/cont-init.d/98-crowdsec
+++ b/root/etc/cont-init.d/98-crowdsec
@@ -56,8 +56,22 @@ sed -ir "s|SECRET_KEY=.*$|SECRET_KEY=${CROWDSEC_SECRET_KEY}|" "${CONFIG_PATH}cro
 sed -ir "s|SITE_KEY=.*$|SITE_KEY=${CROWDSEC_SITE_KEY}|" "${CONFIG_PATH}crowdsec-nginx-bouncer.conf"
 
 # Sed in crowdsec include
-if grep -q '#include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
-    sed -i 's|#include /etc/nginx/http.d/\*.conf;|include /etc/nginx/http.d/\*.conf;|' /config/nginx/nginx.conf
+if ! grep -q '[^#]include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
+    if grep -q '#include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
+        # Enable http.d include
+        sed -i 's|#include /etc/nginx/http.d/\*.conf;|include /etc/nginx/http.d/\*.conf;|' /config/nginx/nginx.conf
+    else
+        # Warn about missing http.d include
+        echo "
+        ***************************************************************
+        *    Warning: Your nginx.conf is missing required settings    *
+        *    Please add:                                              *
+        *        include /etc/nginx/http.d/*.conf;                    *
+        *    to the http{} block and restart the container.           *
+        *                                                             *
+        *    The bouncer will not function until this is done.        *
+        ***************************************************************"
+    fi
 fi
 
 # Clean up


### PR DESCRIPTION
Handle cases where user's nginx.conf doesn't have a commented-out http.d include to uncomment and log a warning advising the user what steps to take.

We could in theory sed in the include but it's probably not wise given the potential for breaking a working setup.