### PR TITLE
Check for conf.d include as well as http.d

### DIFF
--- a/root/etc/cont-init.d/98-crowdsec
+++ b/root/etc/cont-init.d/98-crowdsec
@@ -56,7 +56,7 @@ sed -ir "s|SECRET_KEY=.*$|SECRET_KEY=${CROWDSEC_SECRET_KEY}|" "${CONFIG_PATH}cro
 sed -ir "s|SITE_KEY=.*$|SITE_KEY=${CROWDSEC_SITE_KEY}|" "${CONFIG_PATH}crowdsec-nginx-bouncer.conf"
 
 # Sed in crowdsec include
-if ! grep -q '[^#]include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
+if ! grep -q '[^#]include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf' && ! grep -q '[^#]include /etc/nginx/conf.d/\*.conf;' '/config/nginx/nginx.conf'; then
     if grep -q '#include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
         # Enable http.d include
         sed -i 's|#include /etc/nginx/http.d/\*.conf;|include /etc/nginx/http.d/\*.conf;|' /config/nginx/nginx.conf


### PR DESCRIPTION
New versions of nginx on Alpine ship with
```
    # Includes virtual hosts configs.
    # include /etc/nginx/http.d/*.conf;

    # WARNING: Don't use this directory for virtual hosts anymore.
    # This include will be moved to the root context in Alpine 3.14.
    # include /etc/nginx/conf.d/*.conf;
```
Old versions ship with 
```
    # Virtual Host Configs
    ##
    include /etc/nginx/conf.d/*.conf;
```
And
```
/etc/nginx/conf.d -> /etc/nginx/http.d
```
So the previous warning would show for users with working setups, and would break things if they actually followed it.