### PR TITLE
Lidarr: flac2mp3 release 2.0

### DIFF
--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -20,9 +20,10 @@ jobs:
           cat <<EOF
           Building version $VERSION
           EOF
+          # Insert version into scripts
+          sed -i -e "s/{{VERSION}}/$VERSION/" $GITHUB_WORKSPACE/root/usr/local/bin/flac2mp3.sh $GITHUB_WORKSPACE/root/etc/cont-init.d/98-flac2mp3
           # Build image
-          docker build --build-arg VERSION=$VERSION \
-                       --no-cache \
+          docker build --no-cache \
                        --tag ${{ github.sha }} .
       - name: Tag image
         if: ${{ github.ref == format('refs/heads/{0}-{1}', env.BASEIMAGE, env.MODNAME) }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 ## Buildstage ##
 FROM lsiobase/ubuntu:xenial as buildstage
 
-# Build arguments
-ARG VERSION
-
-# Add version number for use in container init script
-RUN mkdir -p /root-layer/etc && \
-  echo "$VERSION" > /root-layer/etc/version.tc989
-
 # Stage local files
 COPY root/ /root-layer/
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest major and minor version are supported.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.3.x   | :heavy_check_mark: |
-| < 1.3   | :x:                |
+| 2.0.x   | :heavy_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/root/etc/cont-init.d/98-flac2mp3
+++ b/root/etc/cont-init.d/98-flac2mp3
@@ -7,7 +7,7 @@ Repos:
   Dev/test: https://github.com/TheCaptain989/lidarr-flac2mp3
   Prod: https://github.com/linuxserver/docker-mods/tree/lidarr-flac2mp3
 
-Version: $(cat /etc/version.tc989)
+Version: {{VERSION}}
 ----------------
 EOF
 

--- a/root/usr/local/bin/flac2alac.sh
+++ b/root/usr/local/bin/flac2alac.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+. /usr/local/bin/flac2mp3.sh -a "-vn -c:a alac" -e m4a

--- a/root/usr/local/bin/flac2mp3-debug-2.sh
+++ b/root/usr/local/bin/flac2mp3-debug-2.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+. /usr/local/bin/flac2mp3.sh -d 2

--- a/root/usr/local/bin/flac2mp3-debug.sh
+++ b/root/usr/local/bin/flac2mp3-debug.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-. /usr/local/bin/flac2mp3.sh -d
+. /usr/local/bin/flac2mp3.sh -d 1

--- a/root/usr/local/bin/flac2mp3.sh
+++ b/root/usr/local/bin/flac2mp3.sh
@@ -8,66 +8,262 @@
 # Dependencies:
 #  ffmpeg
 #  awk
+#  curl
+#  jq
 #  stat
 #  nice
+#  basename
+#  printenv
 #  chmod
 
 # Exit codes:
 #  0 - success; or test
-#  1 - no tracks files found in environment
-#  2 - mkvmerge not found
+#  1 - no audio file specified on command line
+#  2 - ffmpeg not found
 #  3 - invalid command line arguments
+#  5 - specified audio file not found
+#  6 - error when creating output directory
+#  7 - unknown eventtype environment variable
 # 10 - awk script generated an error
+# 20 - general error
 
 ### Variables
 export flac2mp3_script=$(basename "$0")
+export flac2mp3_ver="{{VERSION}}"
 export flac2mp3_pid=$$
 export flac2mp3_config=/config/config.xml
 export flac2mp3_log=/config/logs/flac2mp3.txt
 export flac2mp3_maxlogsize=1024000
 export flac2mp3_maxlog=4
 export flac2mp3_debug=0
-export flac2mp3_tracks="$lidarr_addedtrackpaths"
-[ -z "$flac2mp3_tracks" ] && flac2mp3_tracks="$lidarr_trackfile_path"      # For other event type
+export flac2mp3_keep=0
+export flac2mp3_type=$(printenv | sed -n 's/_eventtype *=.*$//p')
 
-### Functions
+# Usage function
 function usage {
   usage="
-$flac2mp3_script
+$flac2mp3_script   Version: $flac2mp3_ver
 Audio conversion script designed for use with Lidarr
 
 Source: https://github.com/TheCaptain989/lidarr-flac2mp3
 
 Usage:
-  $0 [-d] [-b <bitrate> | -v <quality> | -a \"<options>\" -e <extension>]
+  $0 [OPTIONS] [-b <bitrate> | -v <quality> | -a \"<options>\" -e <extension>]
+  $0 [OPTIONS] {-f|--file} <audio_file>
 
 Options:
-  -d               enable debug logging
-  -b <bitrate>     set output quality in constant bits per second [default: 320k]
-                   Ex: 160k, 240k, 300000
-  -v <quality>     set variable bitrate; quality between 0-9
-                   0 is highest quality, 9 is lowest
-                   See https://trac.ffmpeg.org/wiki/Encode/MP3 for more details
-  -a \"<options>\"   advanced ffmpeg options enclosed in quotes
-                   Specified options replace all script defaults and are sent as
-                   entered to ffmpeg for processing.
-                   See https://ffmpeg.org/ffmpeg.html#Options for details on valid options.
-                   WARNING: You must specify an audio codec!
-                   WARNING: Invalid options could result in script failure!
-                   Requires -e option to also be specified
-                   See https://github.com/TheCaptain989/lidarr-flac2mp3 for more details
-  -e <extension>   file extension for output file, with or without dot
-                   Required when -a is specified!
+  -d, --debug [<level>]         enable debug logging
+                                Level is optional, default of 1 (low)
+  -b, --bitrate <bitrate>       set output quality in constant bits per second
+                                [default: 320k]
+                                Ex: 160k, 240k, 300000
+  -v, --quality <quality>       set variable bitrate; quality between 0-9
+                                0 is highest quality, 9 is lowest
+                                For more details, see:
+                                https://trac.ffmpeg.org/wiki/Encode/MP3
+  -a, --advanced \"<options>\"    advanced ffmpeg options enclosed in quotes
+                                Specified options replace all script defaults
+                                and are sent as entered to ffmpeg for
+                                processing.
+                                For more details on valid options, see:
+                                https://ffmpeg.org/ffmpeg.html#Options
+                                WARNING: You must specify an audio codec!
+                                WARNING: Invalid options could result in script
+                                failure!
+                                Requires -e option to also be specified
+                                For more details, see:
+                                https://github.com/TheCaptain989/lidarr-flac2mp3
+  -e, --extension <extension>   file extension for output file, with or without
+                                dot
+                                Required when -a is specified!
+  -f, --file <audio_file>       the script enters batch mode, using the
+                                specified audio file as input
+                                WARNING: Do not use this argument when called
+                                from Lidarr!
+  -o, --output <directory>      specify a directory for the converted audio
+                                file(s)
+                                This will be created if it does not exist.
+  -k, --keep-file               do not delete the source file or move it to the
+                                Lidarr Recycle bin
+                                This also disables the Lidarr rescan.
+      --help                    display this help and exit
+      --version                 display script version and exit
 
 Examples:
-  $flac2mp3_script -b 320k                # Output 320 kbit/s MP3 (non VBR; same as default behavior)
-  $flac2mp3_script -v 0                   # Output variable bitrate MP3, VBR 220-260 kbit/s
-  $flac2mp3_script -d -b 160k             # Enable debugging and set output a 160 kbit/s MP3
-  $flac2mp3_script -a \"-vn -c:a libopus -b:a 192K\" -e .opus     # Convert to Opus format, VBR 192 kbit/s, no cover art
-  $flac2mp3_script -a \"-y -map 0 -c:a aac -b:a 240K -c:v copy\" -e mp4     # Convert to MP4 format, using AAC 240 kbit/s audio, cover art, overwrite file
+  $flac2mp3_script -b 320k           # Output 320 kbit/s MP3 (non-VBR; same as
+                                  default behavior)
+  $flac2mp3_script -v 0              # Output variable bitrate MP3, VBR 220-260
+                                  kbit/s
+  $flac2mp3_script -d -b 160k        # Enable debugging level 1 and set output a
+                                  160 kbit/s MP3
+  $flac2mp3_script -a \"-vn -c:a libopus -b:a 192K\" -e .opus
+                                # Convert to Opus format, VBR 192 kbit/s, no
+                                  cover art
+  $flac2mp3_script -a \"-y -map 0 -c:a aac -b:a 240K -c:v copy\" -e mp4
+                                # Convert to MP4 format, using AAC 240 kbit/s
+                                  audio, cover art, overwrite file
+  $flac2mp3_script -f \"/path/to/audio/a-ha/Hunting High and Low/01 Take on Me.flac\"
+                                # Batch Mode
+                                  Output 320 kbit/s MP3
+  $flac2mp3_script -o \"/path/to/audio\" -k
+                                # Place the converted file(s) in specified
+                                  directory and do not delete the original audio
+                                  file(s).
 "
   echo "$usage" >&2
 }
+
+# Process arguments
+while (( "$#" )); do
+  case "$1" in
+    -d|--debug ) # Enable debugging, with optional level
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        export flac2mp3_debug=$2
+        shift 2
+      else
+        export flac2mp3_debug=1
+        shift
+      fi
+      ;;
+    --help ) # Display usage
+      usage
+      exit 0
+      ;;
+    --version ) # Display version
+      echo "$flac2mp3_script $flac2mp3_ver"
+      exit 0
+      ;;
+    -f|--file ) # Batch Mode
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        # Overrides detected *_eventtype
+        export flac2mp3_type="batch"
+        export flac2mp3_tracks="$2"
+        shift 2
+      else
+        echo "Error|Invalid option: $1 requires an argument." >&2
+        usage
+        exit 1
+      fi
+      ;;
+    -b|--bitrate ) # Set constant bit rate
+      if [ -n "$flac2mp3_vbrquality" ]; then
+        echo "Error|Both -b and -v options cannot be set at the same time." >&2
+        usage
+        exit 3
+      elif [ -n "$flac2mp3_ffmpegadv" -o -n "$flac2mp3_extension" ]; then
+        echo "Error|The -a and -e options cannot be set at the same time as either -v or -b options." >&2
+        usage
+        exit 3
+      elif [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        export flac2mp3_bitrate="$2"
+        shift 2
+      else
+        echo "Error|Invalid option: $1 requires an argument." >&2
+        usage
+        exit 3
+      fi
+      ;;
+    -v|--quality ) # Set variable quality
+      if [ -n "$flac2mp3_bitrate" ]; then
+        echo "Error|Both -v and -b options cannot be set at the same time." >&2
+        usage
+        exit 3
+      elif [ -n "$flac2mp3_ffmpegadv" -o -n "$flac2mp3_extension" ]; then
+        echo "Error|The -a and -e options cannot be set at the same time as either -v or -b options." >&2
+        usage
+        exit 3
+      elif [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        export flac2mp3_vbrquality="$2"
+        shift 2
+      else
+        echo "Error|Invalid option: $1 requires an argument." >&2
+        usage
+        exit 3
+      fi
+      ;;
+    -a|--advanced ) # Set advanced options
+      if [ -n "$flac2mp3_vbrquality" -o -n "$flac2mp3_bitrate" ]; then
+        echo "Error|The -a and -e options cannot be set at the same time as either -v or -b options." >&2
+        usage
+        exit 3
+      elif [ -n "$2" ]; then
+        export flac2mp3_ffmpegadv="$2"
+        shift 2
+      else
+        echo "Error|Invalid option: $1 requires an argument." >&2
+        usage
+        exit 3
+      fi
+      ;;
+    -e|--extension ) # Set file extension
+      if [ -n "$flac2mp3_vbrquality" -o -n "$flac2mp3_bitrate" ]; then
+        echo "Error|The -a and -e options cannot be set at the same time as either -v or -b options." >&2
+        usage
+        exit 3
+      elif [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        export flac2mp3_extension="$2"
+        shift 2
+      else
+        echo "Error|Invalid option: $1 requires an argument." >&2
+        usage
+        exit 3
+      fi
+      # Test for dot prefix
+      [ "${flac2mp3_extension:0:1}" != "." ] && flac2mp3_extension=".${flac2mp3_extension}"
+      ;;
+    -o|--output ) # Set output directory
+      if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+        export flac2mp3_output="$2"
+        shift 2
+      else
+        echo "Error|Invalid option: $1 requires an argument." >&2
+        usage
+        exit 3
+      fi
+      # Test for trailing slash
+      [ "${flac2mp3_output: -1:1}" != "/" ] && flac2mp3_output="${flac2mp3_output}/"
+      ;;
+    -k|--keep-file ) # Do not delete source file(s)
+      export flac2mp3_keep=1
+      shift
+      ;;
+    -*|--*=) # Unknown option
+      echo "Error|Unknown option: $1" >&2
+      usage
+      exit 20
+      ;;
+    *) # Remove unknown positional parameters
+      shift
+      ;;
+  esac
+done
+
+# Test for either -a and -e, but not both: logical XOR = non-equality
+if [ "${flac2mp3_ffmpegadv:+data}" != "${flac2mp3_extension:+data}" ]; then
+  echo "Error|The -a and -e options must be specified together." >&2
+  usage
+  exit 3
+fi
+
+# Set default bit rate
+[ -z "$flac2mp3_vbrquality" -a -z "$flac2mp3_bitrate" -a -z "$flac2mp3_ffmpegadv" -a -z "$flac2mp3_extension" ] && flac2mp3_bitrate="320k"
+
+## Mode specific variables
+if [[ "${flac2mp3_type,,}" = "batch" ]]; then
+  # Batch mode
+  export lidarr_eventtype="Convert"
+elif [[ "${flac2mp3_type,,}" = "lidarr" ]]; then
+  export flac2mp3_tracks="$lidarr_addedtrackpaths"
+  # Catch for other environment variable
+  [ -z "$flac2mp3_tracks" ] && flac2mp3_tracks="$lidarr_trackfile_path"
+else
+  # Called in an unexpected way
+  echo -e "Error|Unknown or missing 'lidarr_eventtype' environment variable: ${flac2mp3_type}\nNot called within Lidarr?\nTry using Batch Mode option: -f <file>"
+  exit 7
+fi
+
+### Functions
+
 # Can still go over flac2mp3_maxlog if read line is too long
 #  Must include whole function in subshell for read to work!
 function log {(
@@ -94,11 +290,11 @@ function read_xml {
 function rescan {
   flac2mp3_message="Info|Calling Lidarr API to rescan artist"
   echo "$flac2mp3_message" | log
-  [ $flac2mp3_debug -eq 1 ] && echo "Debug|Forcing rescan of artist '$lidarr_artist_id'. Calling Lidarr API 'RefreshArtist' using POST and URL '$flac2mp3_api_url/command'" | log
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Forcing rescan of artist '$lidarr_artist_id'. Calling Lidarr API 'RefreshArtist' using POST and URL '$flac2mp3_api_url/command'" | log
   flac2mp3_result=$(curl -s -H "X-Api-Key: $flac2mp3_apikey" \
     -d "{\"name\": 'RefreshArtist', \"artistId\": $lidarr_artist_id}" \
     -X POST "$flac2mp3_api_url/command")
-  [ $flac2mp3_debug -eq 1 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
+  [ $flac2mp3_debug -ge 2 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
   flac2mp3_jobid="$(echo $flac2mp3_result | jq -crM .id)"
   if [ "$flac2mp3_jobid" != "null" ]; then
     local flac2mp3_return=0
@@ -111,10 +307,10 @@ function rescan {
 function check_rescan {
   local i=0
   for ((i=1; i <= 15; i++)); do
-    [ $flac2mp3_debug -eq 1 ] && echo "Debug|Checking job $flac2mp3_jobid completion, try #$i. Calling Lidarr API using GET and URL '$flac2mp3_api_url/command/$flac2mp3_jobid'" | log
+    [ $flac2mp3_debug -ge 1 ] && echo "Debug|Checking job $flac2mp3_jobid completion, try #$i. Calling Lidarr API using GET and URL '$flac2mp3_api_url/command/$flac2mp3_jobid'" | log
     flac2mp3_result=$(curl -s -H "X-Api-Key: $flac2mp3_apikey" \
       -X GET "$flac2mp3_api_url/command/$flac2mp3_jobid")
-    [ $flac2mp3_debug -eq 1 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
+    [ $flac2mp3_debug -ge 2 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
     if [ "$(echo $flac2mp3_result | jq -crM .status)" = "completed" ]; then
       local flac2mp3_return=0
       break
@@ -125,7 +321,7 @@ function check_rescan {
       else
         # It may have timed out, so let's wait a second
         local flac2mp3_return=1
-        [ $flac2mp3_debug -eq 1 ] && echo "Debug|Job not done.  Waiting 1 second." | log
+        [ $flac2mp3_debug -ge 1 ] && echo "Debug|Job not done.  Waiting 1 second." | log
         sleep 1
       fi
     fi
@@ -133,107 +329,35 @@ function check_rescan {
   return $flac2mp3_return
 }
 
-# Process options
-while getopts ":db:v:a:e:" opt; do
-  case ${opt} in
-    d ) # For debug purposes only
-      flac2mp3_message="Debug|Enabling debug logging."
-      echo "$flac2mp3_message" | log
-      echo "$flac2mp3_message" >&2
-      flac2mp3_debug=1
-      printenv | sort | sed 's/^/Debug|/' | log
-      ;;
-    b ) # Set constant bit rate
-      if [ -n "$flac2mp3_vbrquality" ]; then
-        flac2mp3_message="Error|Both -b and -v options cannot be set at the same time."
-        echo "$flac2mp3_message" | log
-        echo "$flac2mp3_message" >&2
-        usage
-        exit 3
-      elif [ -n "$flac2mp3_ffmpegadv" -o -n "$flac2mp3_extension" ]; then
-        flac2mp3_message="Error|The -a and -e options cannot be set at the same time as either -v or -b options."
-        echo "$flac2mp3_message" | log
-        echo "$flac2mp3_message" >&2
-        usage
-        exit 3
-      else
-        flac2mp3_bitrate="$OPTARG"
-      fi
-      ;;
-    v ) # Set variable quality
-      if [ -n "$flac2mp3_bitrate" ]; then
-        flac2mp3_message="Error|Both -v and -b options cannot be set at the same time."
-        echo "$flac2mp3_message" | log
-        echo "$flac2mp3_message" >&2
-        usage
-        exit 3
-      elif [ -n "$flac2mp3_ffmpegadv" -o -n "$flac2mp3_extension" ]; then
-        flac2mp3_message="Error|The -a and -e options cannot be set at the same time as either -v or -b options."
-        echo "$flac2mp3_message" | log
-        echo "$flac2mp3_message" >&2
-        usage
-        exit 3
-      else
-        flac2mp3_vbrquality="$OPTARG"
-      fi
-      ;;
-    a ) # Set advanced options
-      if [ -n "$flac2mp3_vbrquality" -o -n "$flac2mp3_bitrate" ]; then
-        flac2mp3_message="Error|The -a and -e options cannot be set at the same time as either -v or -b options."
-        echo "$flac2mp3_message" | log
-        echo "$flac2mp3_message" >&2
-        usage
-        exit 3
-      else
-        flac2mp3_ffmpegadv="$OPTARG"
-      fi
-      ;;
-    e ) # Set file extension
-      if [ -n "$flac2mp3_vbrquality" -o -n "$flac2mp3_bitrate" ]; then
-        flac2mp3_message="Error|The -a and -e options cannot be set at the same time as either -v or -b options."
-        echo "$flac2mp3_message" | log
-        echo "$flac2mp3_message" >&2
-        usage
-        exit 3
-      else
-        flac2mp3_extension="$OPTARG"
-      fi
-      # Test for dot
-      [ "${flac2mp3_extension:0:1}" != "." ] && flac2mp3_extension=".${flac2mp3_extension}"
-      ;;
-    : ) # No required argument specified
-      flac2mp3_message="Error|Invalid option: -${OPTARG} requires an argument"
-      echo "$flac2mp3_message" | log
-      echo "$flac2mp3_message" >&2
-      usage
-      exit 3
-      ;;
-    * ) # Unknown option
-      flac2mp3_message="Error|Unknown option: -${OPTARG}"
-      echo "$flac2mp3_message" | log
-      echo "$flac2mp3_message" >&2
-      usage
-      exit 3
-      ;;
-  esac
-done
-# Test for either -a and -e, but not both: logical XOR = non-equality
-if [ "${flac2mp3_ffmpegadv:+data}" != "${flac2mp3_extension:+data}" ]; then
-  flac2mp3_message="Error|The -a and -e options must be specified together."
+# Check for required binaries
+if [ ! -f "/usr/bin/ffmpeg" ]; then
+  flac2mp3_message="Error|/usr/bin/ffmpeg is required by this script"
   echo "$flac2mp3_message" | log
   echo "$flac2mp3_message" >&2
-  usage
-  exit 3
+  exit 2
 fi
-shift $((OPTIND -1))
 
-# Set default bit rate
-[ -z "$flac2mp3_vbrquality" -a -z "$flac2mp3_bitrate" -a -z "$flac2mp3_ffmpegadv" -a -z "$flac2mp3_extension" ] && flac2mp3_bitrate="320k"
+# Log Debug state
+if [ $flac2mp3_debug -ge 1 ]; then
+  flac2mp3_message="Debug|Enabling debug logging level ${flac2mp3_debug}. Starting ${lidarr_eventtype^} run."
+  echo "$flac2mp3_message" | log
+  echo "$flac2mp3_message" >&2
+fi
+
+# Log environment
+[ $flac2mp3_debug -ge 2 ] && printenv | sort | sed 's/^/Debug|/' | log
+
+# Log Batch mode
+if [ "$flac2mp3_type" = "batch" ]; then
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Switching to batch mode. Input filename: ${flac2mp3_tracks}" | log
+fi
 
 # Check for config file
-if [ -f "$flac2mp3_config" ]; then
+if [ "$flac2mp3_type" = "batch" ]; then
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Not using config file in batch mode." | log
+elif [ -f "$flac2mp3_config" ]; then
   # Read Lidarr config.xml
-  [ $flac2mp3_debug -eq 1 ] && echo "Debug|Reading from Lidarr config file '$flac2mp3_config'" | log
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Reading from Lidarr config file '$flac2mp3_config'" | log
   while read_xml; do
     [[ $flac2mp3_xml_entity = "Port" ]] && flac2mp3_port=$flac2mp3_xml_content
     [[ $flac2mp3_xml_entity = "UrlBase" ]] && flac2mp3_urlbase=$flac2mp3_xml_content
@@ -247,16 +371,30 @@ if [ -f "$flac2mp3_config" ]; then
   flac2mp3_api_url="http://$flac2mp3_bindaddress:$flac2mp3_port$flac2mp3_urlbase/api/v1"
 
   # Check Lidarr version
-  [ $flac2mp3_debug -eq 1 ] && echo "Debug|Getting Lidarr version. Calling Lidarr API using GET and URL '$flac2mp3_api_url/system/status'" | log
-  flac2mp3_version=$(curl -s -H "X-Api-Key: $flac2mp3_apikey" \
-    -X GET "$flac2mp3_api_url/system/status" | jq -crM .version)
-  [ $flac2mp3_debug -eq 1 ] && echo "Debug|Detected Lidarr version $flac2mp3_version" | log
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Getting Lidarr version. Calling Lidarr API using GET and URL '$flac2mp3_api_url/system/status'" | log
+  flac2mp3_result=$(curl -s -H "X-Api-Key: $flac2mp3_apikey" \
+    -X GET "$flac2mp3_api_url/system/status")
+  flac2mp3_return=$?; [ "$flac2mp3_return" != 0 ] && {
+    flac2mp3_message="Error|[$flac2mp3_return] curl error when parsing: \"$flac2mp3_api_url/system/status\""
+    echo "$flac2mp3_message" | log
+    echo "$flac2mp3_message" >&2
+  }
+  [ $flac2mp3_debug -ge 2 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
+  flac2mp3_version="$(echo $flac2mp3_result | jq -crM .version)"
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Detected Lidarr version $flac2mp3_version" | log
 
   # Get RecycleBin
-  [ $flac2mp3_debug -eq 1 ] && echo "Debug|Getting Lidarr RecycleBin. Calling Lidarr API using GET and URL '$flac2mp3_api_url/config/mediamanagement'" | log
-  flac2mp3_recyclebin=$(curl -s -H "X-Api-Key: $flac2mp3_apikey" \
-    -X GET "$flac2mp3_api_url/config/mediamanagement" | jq -crM .recycleBin)
-  [ $flac2mp3_debug -eq 1 ] && echo "Debug|Detected Lidarr RecycleBin '$flac2mp3_recyclebin'" | log
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Getting Lidarr RecycleBin. Calling Lidarr API using GET and URL '$flac2mp3_api_url/config/mediamanagement'" | log
+  flac2mp3_result=$(curl -s -H "X-Api-Key: $flac2mp3_apikey" \
+    -X GET "$flac2mp3_api_url/config/mediamanagement")
+  flac2mp3_return=$?; [ "$flac2mp3_return" != 0 ] && {
+    flac2mp3_message="Error|[$flac2mp3_return] curl error when parsing: \"$flac2mp3_api_url/v3/config/mediamanagement\""
+    echo "$flac2mp3_message" | log
+    echo "$flac2mp3_message" >&2
+  }
+  [ $flac2mp3_debug -ge 2 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
+  flac2mp3_recyclebin="$(echo $flac2mp3_result | jq -crM .recycleBin)"
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Detected Lidarr RecycleBin '$flac2mp3_recyclebin'" | log
 else
   # No config file means we can't call the API.  Best effort at this point.
   flac2mp3_message="Warn|Unable to locate Lidarr config file: '$flac2mp3_config'"
@@ -267,46 +405,62 @@ fi
 # Handle Lidarr Test event
 if [[ "$lidarr_eventtype" = "Test" ]]; then
   echo "Info|Lidarr event: $lidarr_eventtype" | log
-  echo "Info|Script was test executed successfully." | log
+  flac2mp3_message="Info|Script was test executed successfully."
+  echo "$flac2mp3_message" | log
+  echo "$flac2mp3_message" >&2
   exit 0
 fi
 
-# Check if called from within Lidarr
-if [ -z "$flac2mp3_tracks" ]; then
-  flac2mp3_message="Error|No track file(s) specified! Not called from Lidarr?"
+# Check if source audio file exists
+if [ "$flac2mp3_type" = "batch" -a ! -f "$flac2mp3_tracks" ]; then
+  flac2mp3_message="Error|Input file not found: \"$flac2mp3_tracks\""
   echo "$flac2mp3_message" | log
   echo "$flac2mp3_message" >&2
-  usage
-  exit 1
+  exit 5
 fi
 
-# Check for required binaries
-if [ ! -f "/usr/bin/ffmpeg" ]; then
-  flac2mp3_message="Error|/usr/bin/ffmpeg is required by this script"
-  echo "$flac2mp3_message" | log
-  echo "$flac2mp3_message" >&2
-  exit 2
+# If specified, check if destination folder exists and create if necessary
+if [ "$flac2mp3_output" -a ! -d "$flac2mp3_output" ]; then
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Destination directory does not exist.  Creating: $flac2mp3_output" | log
+  mkdir -p "$flac2mp3_output"
+  flac2mp3_return=$?; [ "$flac2mp3_return" != 0 ] && {
+    flac2mp3_message="Error|[$flac2mp3_return] mkdir returned an error.  Unable to create output directory."
+    echo "$flac2mp3_message" | log
+    echo "$flac2mp3_message" >&2
+    exit 6
+  }
 fi
 
 # Legacy one-liner script for posterity
 #find "$lidarr_artist_path" -name "*.flac" -exec bash -c 'ffmpeg -loglevel warning -i "{}" -y -acodec libmp3lame -b:a 320k "${0/.flac}.mp3" && rm "{}"' {} \;
 
-#### MAIN
-flac2mp3_message="Info|Lidarr event: ${lidarr_eventtype}, Artist: ${lidarr_artist_name} (${lidarr_artist_id}), Album: ${lidarr_album_title} (${lidarr_album_id}), "
-if [ -z "$flac2mp3_ffmpegadv" ]; then
-  flac2mp3_message+="Export bitrate: ${flac2mp3_bitrate:-$flac2mp3_vbrquality}"
-else
-  flac2mp3_message+="Advanced options: '${flac2mp3_ffmpegadv}', File extension: ${flac2mp3_extension}"
+#### BEGIN MAIN
+flac2mp3_message="Info|Lidarr event: ${lidarr_eventtype}"
+if [ "$flac2mp3_type" != "batch" ]; then
+  flac2mp3_message+=", Artist: ${lidarr_artist_name} (${lidarr_artist_id}), Album: ${lidarr_album_title} (${lidarr_album_id})"
 fi
-flac2mp3_message+=", Tracks: ${flac2mp3_tracks}"
-
+if [ -z "$flac2mp3_ffmpegadv" ]; then
+  flac2mp3_message+=", Export bitrate: ${flac2mp3_bitrate:-$flac2mp3_vbrquality}"
+else
+  flac2mp3_message+=", Advanced options: '${flac2mp3_ffmpegadv}', File extension: ${flac2mp3_extension}"
+fi
+if [ -n "$flac2mp3_output" ]; then
+  flac2mp3_message+=", Output: ${flac2mp3_output}"
+fi
+if [ $flac2mp3_keep = 1 ]; then
+  flac2mp3_message+=", Keep source"
+fi
+flac2mp3_message+=", Track(s): ${flac2mp3_tracks}"
 echo "${flac2mp3_message}" | log
-echo "$flac2mp3_tracks" | awk -v Debug=$flac2mp3_debug \
+
+echo -n "$flac2mp3_tracks" | awk -v Debug=$flac2mp3_debug \
 -v Recycle="$flac2mp3_recyclebin" \
 -v Bitrate="$flac2mp3_bitrate" \
 -v VBR="$flac2mp3_vbrquality" \
 -v FFmpegADV="$flac2mp3_ffmpegadv" \
--v EXT="$flac2mp3_extension" '
+-v EXT="$flac2mp3_extension" \
+-v Output="$flac2mp3_output" \
+-v Keep="$flac2mp3_keep" '
 BEGIN {
   FFmpeg="/usr/bin/ffmpeg"
   FS="|"
@@ -314,49 +468,53 @@ BEGIN {
   IGNORECASE=1
   if (EXT == "") EXT=".mp3"
   if (Bitrate) {
-    if (Debug) print "Debug|Using constant bitrate of "Bitrate
+    if (Debug >= 1) print "Debug|Using constant bitrate of "Bitrate
     BrCommand="-b:a "Bitrate
-  } else if (VBR) {
-    if (Debug) print "Debug|Using variable quality of "VBR
+  } else if (VBR >= 0) {
+    if (Debug >= 1) print "Debug|Using variable quality of "VBR
     BrCommand="-q:a "VBR
   } else if (FFmpegADV) {
-    if (Debug) print "Debug|Using advanced ffmpeg options: \""FFmpegADV"\""
-    if (Debug) print "Debug|Exporting with file extension "EXT
+    if (Debug >= 1) print "Debug|Using advanced ffmpeg options: \""FFmpegADV"\""
+    if (Debug >= 1) print "Debug|Exporting with file extension "EXT
   }
 }
-/\.flac/ {
+/\.flac$/ {
   # Get each FLAC file name and create a new MP3 (or other) name
   Track=$1
-  sub(/\n/,"",Track)
   NewTrack=substr(Track, 1, length(Track)-5) EXT
+  # Redirect output if asked
+  if (Output) sub(/^.*\//,Output ,NewTrack)
   print "Info|Writing: "NewTrack
   # Check for advanced options
   if (FFmpegADV) FFmpegOPTS=FFmpegADV
   else FFmpegOPTS="-c:v copy -map 0 -y -acodec libmp3lame "BrCommand" -write_id3v1 1 -id3v2_version 3"
   # Convert the track
-  if (Debug) print "Debug|Executing: nice "FFmpeg" -loglevel error -i \""Track"\" "FFmpegOPTS" \""NewTrack"\""
+  if (Debug >= 1) print "Debug|Executing: nice "FFmpeg" -loglevel error -i \""Track"\" "FFmpegOPTS" \""NewTrack"\""
   Result=system("nice "FFmpeg" -loglevel error -i \""Track"\" "FFmpegOPTS" \""NewTrack"\" 2>&1")
   if (Result) {
     print "Error|Exit code "Result" converting \""Track"\""
   } else {
-    if (Recycle == "") {
-      # No Recycle Bin, so check for non-zero size new file and delete the old one
-      if (Debug) print "Debug|Deleting: \""Track"\" and setting permissions on \""NewTrack"\""
-      #Command="[ -s \""NewTrack"\" ] && [ -f \""Track"\" ] && chown --reference=\""Track"\" \""NewTrack"\" && chmod --reference=\""Track"\" \""NewTrack"\" && rm \""Track"\""
-      Command="if [ -s \""NewTrack"\" ]; then if [ -f \""Track"\" ]; then chown --reference=\""Track"\" \""NewTrack"\"; chmod --reference=\""Track"\" \""NewTrack"\"; rm \""Track"\"; fi; fi"
-      if (Debug) print "Debug|Executing: "Command
-      system(Command)
+    if (Keep == 1) {
+      # Do not delete the source file
+      if (Debug >= 1) print "Debug|Keeping original: \""Track"\" and setting permissions on \""NewTrack"\""
+      Command="if [ -s \""NewTrack"\" ]; then if [ -f \""Track"\" ]; then chown --reference=\""Track"\" \""NewTrack"\"; chmod --reference=\""Track"\" \""NewTrack"\"; fi; fi"
     } else {
-      # Recycle Bin is configured, so check if it exists, append a relative path to it from the track, check for non-zero size new file, and move the old one to the Recycle Bin
-      match(Track,/^\/?[^\/]+\//)
-      RecPath=substr(Track,RSTART+RLENGTH)
-      sub(/[^\/]+$/,"",RecPath)
-      RecPath=Recycle RecPath
-      if (Debug) print "Debug|Recycling: \""Track"\" to \""RecPath"\" and setting permissions on \""NewTrack"\""
-      Command="if [ ! -e \""RecPath"\" ]; then mkdir -p \""RecPath"\"; fi; if [ -s \""NewTrack"\" ]; then if [ -f \""Track"\" ]; then chown --reference=\""Track"\" \""NewTrack"\"; chmod --reference=\""Track"\" \""NewTrack"\"; mv -t \""RecPath"\" \""Track"\"; fi; fi"
-      if (Debug) print "Debug|Executing: "Command
-      system(Command)
+      if (Recycle == "") {
+        # No Recycle Bin, so check for non-zero size new file and delete the old one
+        if (Debug >= 1) print "Debug|Deleting: \""Track"\" and setting permissions on \""NewTrack"\""
+        Command="if [ -s \""NewTrack"\" ]; then if [ -f \""Track"\" ]; then chown --reference=\""Track"\" \""NewTrack"\"; chmod --reference=\""Track"\" \""NewTrack"\"; rm \""Track"\"; fi; fi"
+      } else {
+        # Recycle Bin is configured, so check if it exists, append a relative path to it from the track, check for non-zero size new file, and move the old one to the Recycle Bin
+        match(Track,/^\/?[^\/]+\//)
+        RecPath=substr(Track,RSTART+RLENGTH)
+        sub(/[^\/]+$/,"",RecPath)
+        RecPath=Recycle RecPath
+        if (Debug >= 1) print "Debug|Recycling: \""Track"\" to \""RecPath"\" and setting permissions on \""NewTrack"\""
+        Command="if [ ! -e \""RecPath"\" ]; then mkdir -p \""RecPath"\"; fi; if [ -s \""NewTrack"\" ]; then if [ -f \""Track"\" ]; then chown --reference=\""Track"\" \""NewTrack"\"; chmod --reference=\""Track"\" \""NewTrack"\"; mv -t \""RecPath"\" \""Track"\"; fi; fi"
+      }
     }
+    if (Debug >= 2) print "Debug|Executing: "Command
+    system(Command)
   }
 }
 ' | log
@@ -365,15 +523,20 @@ BEGIN {
 
 # Check for awk script completion
 flac2mp3_return="${PIPESTATUS[1]}"    # captures awk exit status
-if [ $flac2mp3_return != "0" ]; then
-  flac2mp3_message="Error|Script exited abnormally.  File permissions issue?"
+if [ "$flac2mp3_return" != 0 ]; then
+  flac2mp3_message="Error|[$flac2mp3_return] Script exited abnormally.  File permissions issue?"
   echo "$flac2mp3_message" | log
   echo "$flac2mp3_message" >&2
   exit 10
 fi
 
 # Call Lidarr API to RescanArtist
-if [ -n "$flac2mp3_api_url" ]; then
+if [ "$flac2mp3_type" = "batch" ]; then
+  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Cannot use API in batch mode." | log
+elif [ $flac2mp3_keep -eq 1 ]; then
+  echo "Info|Original audio file(s) kept, no rescan performed." | log
+elif [ -n "$flac2mp3_api_url" ]; then
+  # Check for artist ID
   if [ "$lidarr_artist_id" ]; then
     # Scan the disk for the new audio tracks
     if rescan; then


### PR DESCRIPTION
## Lots of new features and it still retains backward compatibility!

- Added batch mode per issue [#28](https://github.com/TheCaptain989/lidarr-flac2mp3/issues/28)
- Added ALAC wrapper script per issue [#28](https://github.com/TheCaptain989/lidarr-flac2mp3/issues/28)
- Bug fix for issue [#29](https://github.com/TheCaptain989/lidarr-flac2mp3/issues/29) introduced with release 1.3
- Added output and keep-file options per issue [#30](https://github.com/TheCaptain989/lidarr-flac2mp3/issues/30)
- Moved option check earlier in the script and completely reworked options/arguments processing
- Added long option names
- Added debug info for system API
- Added debug info for config API
- Added multiple debug logging levels, defaults to lowest
  - Default debug level excludes the returned JSON, making it more readable and useful
- Normalized test event output
- Minor fix for error text
- Added version option
- Modified how script version is handled
   - Updated BuildImage.yml
   - Updated Dockerfile
   - Update 98-flac2mp3 init script
- Changed awk pattern match to be more robust
- Removed dedundant system command in awk script
- Updated help text
- Updated README.md
- Updated SECURITY.md