### PR TITLE
Add 127.0.0.1 to cloudflare-real-ip, list of IPs

### DIFF
--- a/root/etc/cont-init.d/98-cloudflare-real-ip
+++ b/root/etc/cont-init.d/98-cloudflare-real-ip
@@ -5,5 +5,6 @@
 printf "set_real_ip_from %b;\n" $(curl -s "https://api.cloudflare.com/client/v4/ips" | jq -r '.result.ipv4_cidrs[]') > /config/nginx/cf_real-ip.conf
 printf "set_real_ip_from %b;\n" $(curl -s "https://api.cloudflare.com/client/v4/ips" | jq -r '.result.ipv6_cidrs[]') >> /config/nginx/cf_real-ip.conf
 printf "set_real_ip_from %b;\n" $(ip route | grep -v default | awk '{print $1}') >> /config/nginx/cf_real-ip.conf
+printf "set_real_ip_from %b;\n" set_real_ip_from 127.0.0.1; >> /config/nginx/cf_real-ip.conf    #Needed when using Cloudflare tunnels
 
 chown abc:abc /config/nginx/cf_real-ip.conf


### PR DESCRIPTION
Needed when using cloudflare tunnels. 
Real IP is not used in swag and all IPs were reported as 127.0.0.1. 
Adding this, solved the issue.
