### PR TITLE
[universal-stdout-logs] Use tail -F to follow rotated log files

### DIFF
--- a/root/etc/services.d/stdout-logs/run
+++ b/root/etc/services.d/stdout-logs/run
@@ -2,5 +2,5 @@
 
 TAIL_LOGS=$(echo "$LOGS_TO_STDOUT" | sed 's#|# -f #g')
 
-echo "Executing: tail -f $TAIL_LOGS"
-tail -f $TAIL_LOGS
+echo "Executing: tail -F $TAIL_LOGS"
+tail -F $TAIL_LOGS

--- a/root/etc/services.d/stdout-logs/run
+++ b/root/etc/services.d/stdout-logs/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-TAIL_LOGS=$(echo "$LOGS_TO_STDOUT" | sed 's#|# -f #g')
+TAIL_LOGS=$(echo "$LOGS_TO_STDOUT" | sed 's#|# #g')
 
 echo "Executing: tail -F $TAIL_LOGS"
 tail -F $TAIL_LOGS


### PR DESCRIPTION
I appreciate this mod for keeping an eye on nginx logs and such. The lsio/swag rotates those log files daily, and unfortunately that causes this mod to stop working. I propose using tail's `-F` (a shortcut for `--follow=name --retry`) instead of `-f` so that this mod will continue tailing the newly-rotated log file.