### PR TITLE
Corrected sample country codes

### DIFF
--- a/root/defaults/dbip.conf
+++ b/root/defaults/dbip.conf
@@ -10,13 +10,13 @@ map $geoip2_data_country_iso_code $geo-whitelist {
     default yes;
     # Example for whitelisting a country, comment out 'default yes;' above and uncomment 'default no;' and the whitelisted country below
     # default no;
-    # UK yes;
+    # GB yes;
 }
 
 map $geoip2_data_country_iso_code $geo-blacklist {
     default yes;
     # Example for blacklisting a country, uncomment the blacklisted country below
-    # UK no;
+    # GB no;
  }
 
 geo $lan-ip {


### PR DESCRIPTION
UK is not an ISO 3166-2 code and as such won't work as intended.