### PR TITLE
Remove sample spam

### DIFF
--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -10,7 +10,7 @@ import urllib3
 
 def find_apps():
     apps = {}
-    file_paths = glob.glob("/config/nginx/**/**", recursive=True)
+    file_paths = glob.glob("/config/nginx/**/**.conf", recursive=True)
     auto_confs = glob.glob("/etc/nginx/http.d/*", recursive=True)
     file_paths.extend(auto_confs)
     for file_path in file_paths:


### PR DESCRIPTION
The dashboard is hard to read due to all the .conf.sample files provided by the SWAG container. This small tweak will only detect .conf files (excluding .conf.sample) to reduce the spam.

Side-note: Removing the .sample files does not work. They're re-created on container recreation/update.