### PR TITLE
deprecate arm32 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ RUN \
   echo "**** Downloading x86_64 binary ****" && \
   curl -fL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_MIN_VERSION}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o \
     "/root-layer/julia-bins/julia-x86_64.tar.gz" && \
-  echo "**** Downloading armv7l binary ****" && \
-  curl -fL "https://julialang-s3.julialang.org/bin/linux/armv7l/${JULIA_MIN_VERSION}/julia-${JULIA_VERSION}-linux-armv7l.tar.gz" -o \
-    "/root-layer/julia-bins/julia-armv7l.tar.gz" && \
   echo "**** Downloading aarch64 binary ****" && \
   curl -fL "https://julialang-s3.julialang.org/bin/linux/aarch64/${JULIA_MIN_VERSION}/julia-${JULIA_VERSION}-linux-aarch64.tar.gz" -o \
     "/root-layer/julia-bins/julia-aarch64.tar.gz"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 This mod adds a Julia dev environment to code-server/openvscode-server, to be installed/updated during container start.
 
+**This mod no longer supports arm32v7 due to upstream binaries no longer guaranteed to be available on it per [this post](https://discourse.julialang.org/t/is-the-linux-armv7l-binary-deprecated/85924/2).**
+
 In code-server docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:code-server-julia`
 
 If adding multiple mods, enter them in an array separated by `|`, such as `DOCKER_MODS=linuxserver/mods:code-server-julia|linuxserver/mods:code-server-mod2`
 
-By default, the latest stable version of Julia will be installed. If you'd like to install a different version, you can specify the version as a tag, from a list of published tags: https://hub.docker.com/r/linuxserver/mods/tags?page=1&name=code-server-julia (ie. `DOCKER_MODS=linuxserver/mods:code-server-julia-1.7.2`).
+By default, the latest stable version of Julia will be installed. If you'd like to install a different version, you can specify the version as a tag, from a list of published tags: https://hub.docker.com/r/linuxserver/mods/tags?page=1&name=code-server-julia (ie. `DOCKER_MODS=linuxserver/mods:code-server-julia-1.8.0`).

--- a/root/etc/cont-init.d/98-julia
+++ b/root/etc/cont-init.d/98-julia
@@ -1,8 +1,27 @@
 #!/usr/bin/with-contenv bash
 
+ARCH=$(uname -m)
+if [ "${ARCH}" = "armv7l" ]; then
+  echo '
+*********************************************************
+*********************************************************
+****                                                 ****
+****    julia binaries are no longer guaranteed      ****
+****                                                 ****
+****         to be available on arm32v7              ****
+****                                                 ****
+****     therefore this mod no longer supports       ****
+****                                                 ****
+****                  arm32v7                        ****
+****                                                 ****
+*********************************************************
+*********************************************************
+'
+  exit 0
+fi
+
 if [ -d "/julia-bins" ]; then
   echo "**** Installing/updating Julia ****"
-  ARCH=$(uname -m)
   mkdir -p /julia
   tar xf "/julia-bins/julia-${ARCH}.tar.gz" -C \
     /julia --strip-components=1


### PR DESCRIPTION
upstream no longer guarantees binaries for arm32