### PR TITLE
Adjust for compatibility with standard-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Auto-reload - Docker mod for Nginx based images
 
-This mod allows Nginx to be reloaded automatically whenever there are valid changes to the `*.conf` files in `/config/nginx` or any files in the following folders:
-
-- /config/nginx/proxy-confs
-- /config/nginx/site-confs
+This mod allows Nginx to be reloaded automatically whenever there are new files, or valid changes to the files in `/config/nginx`.
 
 In the container's docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:swag-auto-reload`
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # Auto-reload - Docker mod for Nginx based images
 
-This mod allows Nginx to be reloaded automatically whenever there are valid changes to the following files and folders:
-- /config/nginx/authelia-location.conf
-- /config/nginx/authelia-server.conf
-- /config/nginx/geoip2.conf
-- /config/nginx/ldap.conf
-- /config/nginx/nginx.conf
+This mod allows Nginx to be reloaded automatically whenever there are valid changes to the `*.conf` files in `/config/nginx` or any files in the following folders:
+
 - /config/nginx/proxy-confs
-- /config/nginx/proxy.conf
 - /config/nginx/site-confs
-- /config/nginx/ssl.conf
 
 In the container's docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:swag-auto-reload`
 

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-swag-auto-reload/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-swag-auto-reload/run
@@ -1,30 +1,11 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-DEFAULT_WATCH=()
-mapfile -t DEFAULT_WATCH < <(find /config/nginx -type f -name '*.conf' -print)
-DEFAULT_WATCH+=("/config/nginx/proxy-confs" "/config/nginx/site-confs")
-
-# start with an empty array for active watch
-ACTIVE_WATCH=()
-echo "MOD Auto-reload: Watching the following files/folders for changes"
-for i in "${DEFAULT_WATCH[@]}"; do
-  if [ -f "${i}" ] || [ -d "${i}" ]; then
-    echo "${i}"
-    ACTIVE_WATCH+=("${i}")
-  fi
-done
-for i in $(echo "${WATCHLIST}" | tr "|" " "); do
-  if [ -f "${i}" ] || [ -d "${i}" ]; then
-    echo "${i}"
-    ACTIVE_WATCH+=("${i}")
-  fi
-done
-
 function wait_for_changes {
   inotifywait -rq \
     --event modify,move,create,delete \
-    "${ACTIVE_WATCH[@]}"
+    --excludei '\.(sample|md)' \
+    "/config/nginx"
 }
 
 while wait_for_changes; do

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-swag-auto-reload/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-swag-auto-reload/run
@@ -1,45 +1,41 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-DEFAULT_WATCH=( \
-  /config/nginx/authelia-location.conf \
-  /config/nginx/authelia-server.conf \
-  /config/nginx/geoip2.conf \
-  /config/nginx/ldap.conf \
-  /config/nginx/nginx.conf \
-  /config/nginx/proxy-confs \
-  /config/nginx/proxy.conf \
-  /config/nginx/site-confs \
-  /config/nginx/ssl.conf \
-)
+DEFAULT_WATCH=()
+mapfile -t DEFAULT_WATCH < <(find /config/nginx -type f -name '*.conf' -print)
+DEFAULT_WATCH+=("/config/nginx/proxy-confs" "/config/nginx/site-confs")
 
+# start with an empty array for active watch
+ACTIVE_WATCH=()
 echo "MOD Auto-reload: Watching the following files/folders for changes"
-for i in ${DEFAULT_WATCH[@]}; do
+for i in "${DEFAULT_WATCH[@]}"; do
   if [ -f "${i}" ] || [ -d "${i}" ]; then
     echo "${i}"
-    ACTIVE_WATCH="${ACTIVE_WATCH} ${i}"
+    ACTIVE_WATCH+=("${i}")
   fi
 done
-for i in $(echo "$WATCHLIST" | tr "|" " "); do
+for i in $(echo "${WATCHLIST}" | tr "|" " "); do
   if [ -f "${i}" ] || [ -d "${i}" ]; then
     echo "${i}"
-    ACTIVE_WATCH="${ACTIVE_WATCH} ${i}"
+    ACTIVE_WATCH+=("${i}")
   fi
 done
 
 function wait_for_changes {
   inotifywait -rq \
     --event modify,move,create,delete \
-    ${ACTIVE_WATCH}
+    "${ACTIVE_WATCH[@]}"
 }
 
 while wait_for_changes; do
-  if ! cat /etc/nginx/nginx.conf | grep "/config/nginx/nginx.conf"; then
-    export NGINX_CONF="-c /config/nginx/nginx.conf"
+  NGINX_CONF=()
+  if ! grep -q "/config/nginx/nginx.conf" /etc/nginx/nginx.conf; then
+    NGINX_CONF=("-c" "/config/nginx/nginx.conf")
   fi
-  if /usr/sbin/nginx ${NGINX_CONF} -t; then
+  if /usr/sbin/nginx "${NGINX_CONF[@]}" -t; then
     echo "Changes to nginx config detected and the changes are valid, reloading nginx"
-    /usr/sbin/nginx ${NGINX_CONF} -s reload
+    /usr/sbin/nginx "${NGINX_CONF[@]}" -s reload
   else
     echo "Changes to nginx config detected but the changes are not valid, skipping nginx reload. Please fix your config."
-  fi  
+  fi
 done

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-swag-auto-reload/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-swag-auto-reload/run
@@ -1,11 +1,21 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+echo "MOD Auto-reload: Watching the following files/folders for changes (excluding .sample and .md files):"
+echo "/config/nginx"
+ACTIVE_WATCH=("/config/nginx")
+for i in $(echo "${WATCHLIST}" | tr "|" " "); do
+  if [ -f "${i}" ] || [ -d "${i}" ]; then
+    echo "${i}"
+    ACTIVE_WATCH+=("${i}")
+  fi
+done
+
 function wait_for_changes {
   inotifywait -rq \
     --event modify,move,create,delete \
     --excludei '\.(sample|md)' \
-    "/config/nginx"
+    "${ACTIVE_WATCH[@]}"
 }
 
 while wait_for_changes; do

--- a/root/etc/services.d/inotify/run
+++ b/root/etc/services.d/inotify/run
@@ -1,30 +1,11 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-DEFAULT_WATCH=()
-mapfile -t DEFAULT_WATCH < <(find /config/nginx -type f -name '*.conf' -print)
-DEFAULT_WATCH+=("/config/nginx/proxy-confs" "/config/nginx/site-confs")
-
-# start with an empty array for active watch
-ACTIVE_WATCH=()
-echo "MOD Auto-reload: Watching the following files/folders for changes"
-for i in "${DEFAULT_WATCH[@]}"; do
-  if [ -f "${i}" ] || [ -d "${i}" ]; then
-    echo "${i}"
-    ACTIVE_WATCH+=("${i}")
-  fi
-done
-for i in $(echo "${WATCHLIST}" | tr "|" " "); do
-  if [ -f "${i}" ] || [ -d "${i}" ]; then
-    echo "${i}"
-    ACTIVE_WATCH+=("${i}")
-  fi
-done
-
 function wait_for_changes {
   inotifywait -rq \
     --event modify,move,create,delete \
-    "${ACTIVE_WATCH[@]}"
+    --excludei '\.(sample|md)' \
+    "/config/nginx"
 }
 
 while wait_for_changes; do

--- a/root/etc/services.d/inotify/run
+++ b/root/etc/services.d/inotify/run
@@ -1,42 +1,41 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-DEFAULT_WATCH=( \
-  /config/nginx/authelia-location.conf \
-  /config/nginx/authelia-server.conf \
-  /config/nginx/geoip2.conf \
-  /config/nginx/ldap.conf \
-  /config/nginx/nginx.conf \
-  /config/nginx/proxy-confs \
-  /config/nginx/proxy.conf \
-  /config/nginx/site-confs \
-  /config/nginx/ssl.conf \
-)
+DEFAULT_WATCH=()
+mapfile -t DEFAULT_WATCH < <(find /config/nginx -type f -name '*.conf' -print)
+DEFAULT_WATCH+=("/config/nginx/proxy-confs" "/config/nginx/site-confs")
 
+# start with an empty array for active watch
+ACTIVE_WATCH=()
 echo "MOD Auto-reload: Watching the following files/folders for changes"
-for i in ${DEFAULT_WATCH[@]}; do
+for i in "${DEFAULT_WATCH[@]}"; do
   if [ -f "${i}" ] || [ -d "${i}" ]; then
     echo "${i}"
-    ACTIVE_WATCH="${ACTIVE_WATCH} ${i}"
+    ACTIVE_WATCH+=("${i}")
   fi
 done
-for i in $(echo "$WATCHLIST" | tr "|" " "); do
+for i in $(echo "${WATCHLIST}" | tr "|" " "); do
   if [ -f "${i}" ] || [ -d "${i}" ]; then
     echo "${i}"
-    ACTIVE_WATCH="${ACTIVE_WATCH} ${i}"
+    ACTIVE_WATCH+=("${i}")
   fi
 done
 
 function wait_for_changes {
   inotifywait -rq \
     --event modify,move,create,delete \
-    ${ACTIVE_WATCH}
+    "${ACTIVE_WATCH[@]}"
 }
 
 while wait_for_changes; do
-  if /usr/sbin/nginx -c /config/nginx/nginx.conf -t; then
+  NGINX_CONF=()
+  if ! grep -q "/config/nginx/nginx.conf" /etc/nginx/nginx.conf; then
+    NGINX_CONF=("-c" "/config/nginx/nginx.conf")
+  fi
+  if /usr/sbin/nginx "${NGINX_CONF[@]}" -t; then
     echo "Changes to nginx config detected and the changes are valid, reloading nginx"
-    /usr/sbin/nginx -c /config/nginx/nginx.conf -s reload
+    /usr/sbin/nginx "${NGINX_CONF[@]}" -s reload
   else
     echo "Changes to nginx config detected but the changes are not valid, skipping nginx reload. Please fix your config."
-  fi  
+  fi
 done

--- a/root/etc/services.d/inotify/run
+++ b/root/etc/services.d/inotify/run
@@ -1,11 +1,21 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+echo "MOD Auto-reload: Watching the following files/folders for changes (excluding .sample and .md files):"
+echo "/config/nginx"
+ACTIVE_WATCH=("/config/nginx")
+for i in $(echo "${WATCHLIST}" | tr "|" " "); do
+  if [ -f "${i}" ] || [ -d "${i}" ]; then
+    echo "${i}"
+    ACTIVE_WATCH+=("${i}")
+  fi
+done
+
 function wait_for_changes {
   inotifywait -rq \
     --event modify,move,create,delete \
     --excludei '\.(sample|md)' \
-    "/config/nginx"
+    "${ACTIVE_WATCH[@]}"
 }
 
 while wait_for_changes; do


### PR DESCRIPTION
Find ALL files that end with `*.conf` (instead of a specific list of files). Mostly this covers the new `ldap` files (ref: https://github.com/linuxserver/docker-mods/pull/502 ), but actually is beneficial by covering anything the user could throw at it.