### PR TITLE
code-server-dotnet: update versions filter

### DIFF
--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           # Set version
           DOTNET_JSON="$(curl --retry 5 -sX GET https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json)"
-          DOTNET_VERSIONS="$(echo $DOTNET_JSON | jq -r '."releases-index"[] | select(."support-phase"=="lts" or ."support-phase"=="current") | ."latest-sdk"' | tr '\n' ' ' | head -c -1)"
+          DOTNET_VERSIONS="$(echo $DOTNET_JSON | jq -r '."releases-index"[] | select(."support-phase"=="active" or ."support-phase"=="maintenance") | ."latest-sdk"' | tr '\n' ' ' | head -c -1)"
           DOTNET_TAG="$(echo $DOTNET_VERSIONS | tr ' ' '_')"
           echo "DOTNET_TAG=${DOTNET_TAG}" >> $GITHUB_ENV
           # Build image

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     jq && \
  DOTNET_JSON=$(curl -sX GET "https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json") && \
  if [ -z ${DOTNET_VERSIONS+x} ]; then \
-    DOTNET_VERSIONS=$(echo "$DOTNET_JSON" | jq -r '."releases-index"[] | select(."support-phase"=="lts" or ."support-phase"=="current") | ."latest-sdk"' | tr '\n' ' ' | head -c -1); \
+    DOTNET_VERSIONS=$(echo "$DOTNET_JSON" | jq -r '."releases-index"[] | select(."support-phase"=="active" or ."support-phase"=="maintenance") | ."latest-sdk"' | tr '\n' ' ' | head -c -1); \
  fi && \
  mkdir -p /root-layer/dotnet && \
  echo "$DOTNET_VERSIONS" > /root-layer/dotnet/versions.txt && \


### PR DESCRIPTION
Due to changes in releases-index.json the script won't be able to find any releases anymore. 

I updated the filters to reflect these changes, which are also described [here](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#servicing). 
tl;dr: "active" is, well, actively supported. "active" releases go into "maintenance" 6 months before EOL and from that point on only receive security updates until they reach EOL.