### PR TITLE
Lidarr: flac2mp3 Release 2.2.1

### DIFF
--- a/root/usr/local/bin/flac2mp3.sh
+++ b/root/usr/local/bin/flac2mp3.sh
@@ -454,7 +454,7 @@ elif [ -f "$flac2mp3_config" ]; then
   [ $flac2mp3_debug -ge 2 ] && echo "API returned: $flac2mp3_result" | awk '{print "Debug|"$0}' | log
   flac2mp3_recyclebin="$(echo $flac2mp3_result | jq -crM .recycleBin)"
   # Test for trailing backslash
-  [ "${flac2mp3_recyclebin: -1:1}" != "/" ] && flac2mp3_recyclebin="${flac2mp3_recyclebin}/"
+  [ ${#flac2mp3_recyclebin} -ne 0 -a "${flac2mp3_recyclebin: -1:1}" != "/" ] && flac2mp3_recyclebin="${flac2mp3_recyclebin}/"
   [ $flac2mp3_debug -ge 1 ] && echo "Debug|Detected Lidarr RecycleBin '$flac2mp3_recyclebin'" | log
   
   # Get root folder path from Artist info


### PR DESCRIPTION
## What's Changed Since 2.1
- **Added new --tags option to resolve TheCaptain989/lidarr-flac2mp3#15**
- Recycled files are now moved to subdirectory paths that more closely resemble the original path
- Better error handling in awk script when calling system commands
- Resolves TheCaptain989/lidarr-flac2mp3#37
- Updated command line help
- Updated README