### PR TITLE
jellyfin-amd: jellyfin-amd add rocm-opencl-runtime

### DIFF
--- a/root/etc/cont-init.d/93-amdgpu-repo
+++ b/root/etc/cont-init.d/93-amdgpu-repo
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+if [ ! -f "/etc/apt/sources.list.d/amdgpu-focal.list" ]; then
+    echo "**** Adding amdgpu repo ****"
+    curl -sL --retry 3 https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
+    echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/5.4.1 ubuntu main" > /etc/apt/sources.list.d/amdgpu-focal.list
+fi

--- a/root/etc/cont-init.d/99-rocm-opencl-runtime
+++ b/root/etc/cont-init.d/99-rocm-opencl-runtime
@@ -1,0 +1,23 @@
+#!/usr/bin/with-contenv bash
+
+# Determine if setup is needed
+if [ ! -f "/usr/bin/apt" ]; then
+    echo "**** Image is not Ubuntu, skipping opencl-intel install ****"
+    exit 0
+fi
+
+pkgs='rocm-opencl-runtime'
+
+install=false
+for pkg in $pkgs; do
+    status="$(dpkg-query -W --showformat='${db:Status-Status}' "$pkg" 2>&1)"
+    if [ ! $? = 0 ] || [ ! "$status" = installed ]; then
+        install=true
+        break
+    fi
+done
+
+if "$install"; then
+    echo "**** Installing rocm-opencl-runtime ****"
+    apt-get install -y $pkgs
+fi

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-amd-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-amd-add-package/run
@@ -1,5 +1,7 @@
 #!/usr/bin/with-contenv bash
 
+AMDGPU_RELEASE=${AMDGPU_RELEASE:-5.4.1}
+
 # Determine if setup is needed
 if [ ! -f "/usr/bin/apt" ]; then
     echo "**** Image is not Ubuntu, skipping opencl-intel install ****"
@@ -17,7 +19,14 @@ if [ ! -f "/etc/apt/sources.list.d/kisak-mesa.list" ]; then
     echo "deb http://ppa.launchpad.net/kisak/kisak-mesa/ubuntu ${DISTRIB_CODENAME} main" > /etc/apt/sources.list.d/kisak-mesa.list
 fi
 
-pkgs='mesa-vdpau-drivers mesa-va-drivers mesa-vdpau-drivers libdrm-radeon1'
+if [ ! -f "/etc/apt/sources.list.d/amdgpu-focal.list" ]; then
+    echo "**** Adding amdgpu repo ****"
+    curl -sL --retry 3 https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
+    echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${AMDGPU_RELEASE} ubuntu main" > /etc/apt/sources.list.d/amdgpu-focal.list
+fi
+
+
+pkgs='mesa-vdpau-drivers mesa-va-drivers mesa-vdpau-drivers libdrm-radeon1 rocm-opencl-runtime'
 
 install=false
 for pkg in $pkgs; do
@@ -29,6 +38,6 @@ for pkg in $pkgs; do
 done
 
 if "$install"; then
-    echo "**** Adding mesa to package install list ****"
+    echo "**** Adding mesa and rocm-opencl-runtime to package install list ****"
     echo "$pkgs" >> /mod-repo-packages-to-install.list
 fi


### PR DESCRIPTION
add installation of rocm opencl package to speed up tone mapping

After installation the tone mapping from HDR to SDR works.
Diagnostics ffmpeg picking up opencl
```
$ docker exec -it jellyfin /usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl
ffmpeg version 5.1.2-Jellyfin Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
  configuration: --prefix=/usr/lib/jellyfin-ffmpeg --target-os=linux --extra-libs=-lfftw3f --extra-version=Jellyfin --disable-doc --disable-ffplay --disable-ptx-compression --disable-shared --disable-libxcb --disable-sdl2 --disable-xlib --enable-lto --enable-gpl --enable-version3 --enable-static --enable-gmp --enable-gnutls --enable-chromaprint --enable-libdrm --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libdav1d --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265 --enable-libzvbi --enable-libzimg --enable-libfdk-aac --arch=amd64 --enable-libsvtav1 --enable-libshaderc --enable-libplacebo --enable-vulkan --enable-opencl --enable-vaapi --enable-amf --enable-libmfx --enable-ffnvcodec --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvdec --enable-nvenc
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
Splitting the commandline.
Reading option '-v' ... matched as option 'v' (set logging level) with argument 'debug'.
Reading option '-init_hw_device' ... matched as option 'init_hw_device' (initialise hardware device) with argument 'opencl'.
Finished splitting the commandline.
Parsing a group of options: global .
Applying option v (set logging level) with argument debug.
Applying option init_hw_device (initialise hardware device) with argument opencl.
dlerror: libnvidia-opencl.so.1: cannot open shared object file: No such file or directory
[AVHWDeviceContext @ 0x55d3ea4bfd00] 1 OpenCL platforms found.
[AVHWDeviceContext @ 0x55d3ea4bfd00] 1 OpenCL devices found on platform "AMD Accelerated Parallel Processing".
[AVHWDeviceContext @ 0x55d3ea4bfd00] 0.0: AMD Accelerated Parallel Processing / gfx90c:xnack-
[AVHWDeviceContext @ 0x55d3ea4bfd00] The cl_intel_va_api_media_sharing extension is required for QSV to OpenCL mapping.
[AVHWDeviceContext @ 0x55d3ea4bfd00] QSV to OpenCL mapping not usable.
Successfully parsed a group of options.
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'
```

I've published `https://hub.docker.com/layers/malinskiy/jellyfin-amd/rocm/images/sha256-d2113b9060c7976a5cbb919e175a74ea82d351c895943efff3b198166610f4a8` for now to use on my local setup, you can use it for testing by appending the `malinskiy/jellyfin-amd:rocm` to the mods envvar.