### PR TITLE
added spaces [\s*] between # and include

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-crowdsec/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-crowdsec/run
@@ -62,9 +62,9 @@ cp /tmp/crowdsec/nginx/crowdsec_nginx.conf /etc/nginx/http.d
 
 # Sed in crowdsec include
 if ! grep -q '[^#]include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf' && ! grep -q '[^#]include /etc/nginx/conf.d/\*.conf;' '/config/nginx/nginx.conf'; then
-    if grep -q '#include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
+    if grep -q '#\s*include /etc/nginx/http.d/\*.conf;' '/config/nginx/nginx.conf'; then
         # Enable http.d include
-        sed -i 's|#include /etc/nginx/http.d/\*.conf;|include /etc/nginx/http.d/\*.conf;|' /config/nginx/nginx.conf
+        sed -i 's|#\s*include /etc/nginx/http.d/\*.conf;|include /etc/nginx/http.d/\*.conf;|' /config/nginx/nginx.conf
     else
         # Warn about missing http.d include
         echo "


### PR DESCRIPTION
Some users modify nginx.conf manually as you would expect, and some add a space after the comment #. Either done manually or because of language rules attached to the IDE they use (notepad++ for instance), the grep will never uncomment the include line if there is a space after the #. This is a fix for those cases.