### PR TITLE
code-server-golang: Update run to change Path

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-code-server-golang-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-code-server-golang-add-package/run
@@ -1,15 +1,15 @@
 #!/usr/bin/with-contenv bash
 
 echo "**** ensuring golang is in PATH ****"
-if grep -q -E '^(export )?PATH=' /etc/services.d/code-server/run; then
-    if ! grep -q -E '^(export )?PATH=.*/usr/local/go/bin.*' /etc/services.d/code-server/run; then
-        sed -i '/PATH/ s/$/:\/usr\/local\/go\/bin/' /etc/services.d/code-server/run
+if grep -q -E '^(export )?PATH=' /etc/s6-overlay/s6-rc.d/svc-code-server/run; then
+    if ! grep -q -E '^(export )?PATH=.*/usr/local/go/bin.*' /etc/s6-overlay/s6-rc.d/svc-code-server/run; then
+        sed -i '/PATH/ s/$/:\/usr\/local\/go\/bin/' /etc/s6-overlay/s6-rc.d/svc-code-server/run
     fi
-    if ! grep -q -E '^(export )?PATH=.*/config/go/bin:.*' /etc/services.d/code-server/run; then
-        sed -i 's/PATH=/PATH=\/config\/go\/bin:/g' /etc/services.d/code-server/run
+    if ! grep -q -E '^(export )?PATH=.*/config/go/bin:.*' /etc/s6-overlay/s6-rc.d/svc-code-server/run; then
+        sed -i 's/PATH=/PATH=\/config\/go\/bin:/g' /etc/s6-overlay/s6-rc.d/svc-code-server/run
     fi
 else
-    sed -i '/^#!\/usr\/bin/a \\n# Added by codeserver-golang\nexport PATH=/config/go/bin:$PATH:/usr/local/go/bin' /etc/services.d/code-server/run
+    sed -i '/^#!\/usr\/bin/a \\n# Added by codeserver-golang\nexport PATH=/config/go/bin:$PATH:/usr/local/go/bin' /etc/s6-overlay/s6-rc.d/svc-code-server/run
 fi
 
 ARCH=$(uname -m)


### PR DESCRIPTION
Change /etc/services.d/code-server/run to /etc/s6-overlay/s6-rc.d/svc-code-server/run 

This allows the file to correctly change the path environment variable during the goland package add process. Currently when using the /etc/services.d/code-server/run path it results in an error and the path environment variable unchanged. 

I forked this repo, ran a build image to my own docker repo and was able to test that this change does indeed allow the file to change the environment variable correctly.

#555 This proposed change would fix this open issue.