### PR TITLE
Check if cron running before starting

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-cron/run
@@ -1,5 +1,9 @@
 #!/usr/bin/with-contenv bash
 
+if pidof cron >/dev/null || pidof crond >/dev/null; then
+    exit
+fi
+
 if [ -f /usr/bin/apt ]; then
     # ubuntu
     exec /usr/sbin/cron -f -L 1

--- a/root/etc/services.d/cron/run
+++ b/root/etc/services.d/cron/run
@@ -1,10 +1,13 @@
 #!/usr/bin/with-contenv bash
 
+if pidof cron >/dev/null || pidof crond >/dev/null; then
+    exit
+fi
+
 if [ -f /usr/bin/apt ]; then
     # ubuntu
     exec /usr/sbin/cron -f -L 1
-fi
-if [ -f /sbin/apk ]; then
+elif [ -f /sbin/apk ]; then
     # alpine
     exec /usr/sbin/crond -f -S -l 5
 fi


### PR DESCRIPTION
The nginx container would have multiple instances of cron running causing jobs to fire multiple times.

This will exit the run scripts if cron or crond is already running