### PR TITLE
Update run

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-maxmind-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-maxmind-add-package/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-if ! apk info 2>&1 | grep -q "libmaxminddb"; then
+if ! apk info 2>&1 | egrep "^libmaxminddb$"; then
     echo "**** adding libmaxminddb to package install list ****"
     echo "libmaxminddb" >> /mod-repo-packages-to-install.list
 else


### PR DESCRIPTION
https://discord.com/channels/354974912613449730/605321325204209682/1067807750249255002

basically, the logic was picking up 
libmaxminddb-libs

so it thought libmaxminddb was already installed and would fail to install. this just puts in some regex to determine start and finish to not confuse -libs.