### PR TITLE
swag-dashboard : Provide status on only enabled proxy configs

### DIFF
--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -8,12 +8,11 @@ from pathlib import Path
 import urllib3
 
 
-def get_proxy_conf_file_paths():
+def get_reverse_proxy_conf_file_paths():
     """Get all the active nginx proxy configuration files"""
 
     file_paths = []
 
-    # include reverse proxy configs
     reverse_proxy_conf_extensions = [
         '*.subdomain.conf',
         '*.subfolder.conf'
@@ -27,7 +26,7 @@ def get_proxy_conf_file_paths():
 def find_apps():
     apps = {}
 
-    file_paths = get_proxy_conf_file_paths()
+    file_paths = get_reverse_proxy_conf_file_paths()
 
     for file_path in file_paths:
         if not os.path.isfile(file_path):

--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -1,18 +1,34 @@
 import collections
 import concurrent.futures
-import glob
 import json
 import os
 import re
 import socket
+from pathlib import Path
 import urllib3
+
+
+def get_proxy_conf_file_paths():
+    """Get all the active nginx proxy configuration files"""
+
+    file_paths = []
+
+    # include reverse proxy configs
+    reverse_proxy_conf_extensions = [
+        '*.subdomain.conf',
+        '*.subfolder.conf'
+    ]
+    for ext in reverse_proxy_conf_extensions:
+        file_paths.extend(Path('/config/nginx/proxy-confs').rglob(ext))
+
+    return file_paths
 
 
 def find_apps():
     apps = {}
-    file_paths = glob.glob("/config/nginx/**/**", recursive=True)
-    auto_confs = glob.glob("/etc/nginx/http.d/*", recursive=True)
-    file_paths.extend(auto_confs)
+
+    file_paths = get_proxy_conf_file_paths()
+
     for file_path in file_paths:
         if not os.path.isfile(file_path):
             continue

--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -61,15 +61,15 @@ def is_available(url):
 
 
 urllib3.disable_warnings()
-apps = find_apps()
+found_apps = find_apps()
 discovered_apps = collections.defaultdict(dict)
 with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
-    futures = {executor.submit(is_available, app): app for app in apps.keys()}
+    futures = {executor.submit(is_available, app): app for app in found_apps.keys()}
     for future in concurrent.futures.as_completed(futures):
         app = futures[future]
-        if not future.result() and not apps[app]:
+        if not future.result() and not found_apps[app]:
             continue
         discovered_apps[app]["status"] = future.result()
-        discovered_apps[app]["locations"] = list(apps[app])
+        discovered_apps[app]["locations"] = list(found_apps[app])
 
 print(json.dumps(discovered_apps, sort_keys=True))

--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -40,9 +40,6 @@ def find_apps():
             app = f"{params['proto']}://{params['name']}:{params['port']}/"
             if app not in apps:
                 apps[app] = set()
-            if file_path.startswith("/config/nginx/site-confs/") or file_path.endswith(".conf"):
-                file_path = "auto-proxy" if file_path.startswith("/etc/nginx/http.d/") else file_path
-                apps[app].add(file_path)
     return apps
 
 


### PR DESCRIPTION
This PR is an attempt to resolve the issues identified in #501 and #570.

Basically the active reverse proxy configurations being considered are now explicitly only in the files with the following extensions:

```
*.subdomain.conf
*.subfolder.conf
```

and only in the default SWAG reverse proxy configuration directory which is `/config/nginx/proxy-confs`. This is based off the official documentation [here](https://docs.linuxserver.io/general/swag#preset-proxy-confs) and [here](https://github.com/linuxserver/reverse-proxy-confs#configure-your-default-site-config) that guides users on how to enable different proxy configurations.

I was not sure why conf files under `/config/nginx/site-confs/` and `/etc/nginx/http.d/` where being analysed as you would not normally expect these to contain reverse proxy configurations. I could also not determine where these apps marked as `auto-proxy` where being surfaced to the user. If someone can provide an indication as to how these are used I can restore the relevant lines of code.
