### PR TITLE
Support mods with multi-digest layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 These files are used by Linuxserver build processes to handle mods in our images. Not for end-user consumption.
 
+* **05.02.23:** - Support multi-manifest mods for provenance, etc.
 * **21.01.23:** - Create with-contenv alias.
 * **01.01.23:** - Remove support for legacy custom script/service locations.
 * **25.09.22:** - Initial Release.

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -222,6 +222,10 @@ run_mods() {
                 "${BLOB_URL}${SHALAYER}" -o \
                 /modtarball.tar.xz
             mkdir -p /tmp/mod
+            if ! tar -tzf /modtarball.tar.xz >/dev/null 2>&1; then
+                echo "Invalid tarball, could not download ${DOCKER_MOD}"
+                continue
+            fi
             tar xzf /modtarball.tar.xz -C /tmp/mod
             if [[ -d /tmp/mod/etc/s6-overlay ]]; then
                 if [[ -d /tmp/mod/etc/cont-init.d ]]; then

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -138,6 +138,8 @@ get_blob_sha() {
             --silent \
             --location \
             --request GET \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            --header "Accept: application/vnd.oci.image.index.v1+json" \
             --header "Authorization: Bearer $2" \
             "$3" | jq -r '.layers[0].digest'
     else
@@ -145,6 +147,8 @@ get_blob_sha() {
             --silent \
             --location \
             --request GET \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            --header "Accept: application/vnd.oci.image.index.v1+json" \
             --header "Authorization: Bearer $2" \
             "$3" | jq -r '.fsLayers[0].blobSum'
     fi

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -134,23 +134,69 @@ curl_check() {
 # Use different filtering depending on URL
 get_blob_sha() {
     if [[ $1 == "ghcr" ]]; then
-        curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
+        MULTIDIGEST=$(curl  -f --retry 10 --retry-max-time 60 --retry-connrefused \
             --silent \
             --location \
             --request GET \
             --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
             --header "Accept: application/vnd.oci.image.index.v1+json" \
-            --header "Authorization: Bearer $2" \
-            "$3" | jq -r '.layers[0].digest'
+            --header "Authorization: Bearer ${2}" \
+            "${3}/${TAG}" | jq -r 'first(.manifests[].digest)?')
+        if [[ -z "${MULTIDIGEST}" ]]; then
+            if DIGEST=$(curl  -f --retry 10 --retry-max-time 60 --retry-connrefused \
+                --silent \
+                --location \
+                --request GET \
+                --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+                --header "Accept: application/vnd.oci.image.manifest.v1+json" \
+                --header "Authorization: Bearer ${2}" \
+                "${3}/${TAG}" | grep -v 404); then
+                echo "${DIGEST}" | jq -r '.layers[0].digest';
+            fi
+        else
+            if DIGEST=$(curl  -f --retry 10 --retry-max-time 60 --retry-connrefused \
+                --silent \
+                --location \
+                --request GET \
+                --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+                --header "Accept: application/vnd.oci.image.manifest.v1+json" \
+                --header "Authorization: Bearer ${2}" \
+                "${3}/${MULTIDIGEST}" | grep -v 404); then
+                echo "${DIGEST}" | jq -r '.layers[0].digest';
+            fi
+        fi
     else
-        curl -f --retry 10 --retry-max-time 60 --retry-connrefused \
+        MULTIDIGEST=$(curl  -f --retry 10 --retry-max-time 60 --retry-connrefused \
             --silent \
             --location \
             --request GET \
             --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
             --header "Accept: application/vnd.oci.image.index.v1+json" \
-            --header "Authorization: Bearer $2" \
-            "$3" | jq -r '.fsLayers[0].blobSum'
+            --header "Authorization: Bearer ${2}" \
+            "${3}/${TAG}" | jq -r 'first(.manifests[].digest)?')
+        if [[ -z "${MULTIDIGEST}" ]]; then
+            if DIGEST=$(curl  -f --retry 10 --retry-max-time 60 --retry-connrefused \
+                --silent \
+                --location \
+                --request GET \
+                --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+                --header "Accept: application/vnd.oci.image.manifest.v1+json" \
+                --header "Authorization: Bearer ${2}" \
+                "${3}/${TAG}" | grep -v 404); then
+                echo "${DIGEST}" | jq -r '.layers[0].digest';
+            fi
+        else
+            if DIGEST=$(curl  -f --retry 10 --retry-max-time 60 --retry-connrefused \
+                --silent \
+                --location \
+                --request GET \
+                --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+                --header "Accept: application/vnd.oci.image.manifest.v1+json" \
+                --header "Authorization: Bearer ${2}" \
+                "${3}/${MULTIDIGEST}" | grep -v 404); then
+                echo "${DIGEST}" | jq -r '.layers[0].digest';
+            fi
+        fi
     fi
 }
 
@@ -170,7 +216,7 @@ run_mods() {
             fi
             FILENAME="${USERNAME}.${REPO}.${TAG}"
             AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull"
-            MANIFEST_URL="https://ghcr.io/v2/${ENDPOINT}/manifests/${TAG}"
+            MANIFEST_URL="https://ghcr.io/v2/${ENDPOINT}/manifests"
             BLOB_URL="https://ghcr.io/v2/${ENDPOINT}/blobs/"
             MODE="ghcr"
         else
@@ -183,7 +229,7 @@ run_mods() {
             fi
             FILENAME="${USERNAME}.${REPO}.${TAG}"
             AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${ENDPOINT}:pull"
-            MANIFEST_URL="https://registry-1.docker.io/v2/${ENDPOINT}/manifests/${TAG}"
+            MANIFEST_URL="https://registry-1.docker.io/v2/${ENDPOINT}/manifests"
             BLOB_URL="https://registry-1.docker.io/v2/${ENDPOINT}/blobs/"
             MODE="dockerhub"
         fi


### PR DESCRIPTION
Support mods with multi-digest layers. This allows for provenance layers but *does not* care about multi-arch manifests and will just pick the first manifest regardless of arch.

As a side-effect unifies DH and GHCR with an eye to have a single path in `get_blob_sha()`

Comes after https://github.com/linuxserver/docker-mods/pull/576