### PR TITLE
Use fixed strings for grep patterns

### DIFF
--- a/root/app/auto-proxy.sh
+++ b/root/app/auto-proxy.sh
@@ -18,7 +18,7 @@ else
                 if [ "${VAR_VALUE}" == "null" ]; then
                     VAR_VALUE=""
                 fi
-                if ! grep -q "${VAR}=\"${VAR_VALUE}\"" "/auto-proxy/${CONTAINER}.conf"; then
+                if ! grep -F -q "${VAR}=\"${VAR_VALUE}\"" "/auto-proxy/${CONTAINER}.conf"; then
                     AUTO_GEN="${CONTAINER} ${AUTO_GEN}"
                     echo "**** Labels for ${CONTAINER} changed, will generate new conf. ****"
                     break


### PR DESCRIPTION
If you set a fancy  a swag_url label involving a regex this can trip grep causing it to detect changes *every single run* causing my nginx to just give up now an then when reloading the config :(