### PR TITLE
Update Readme for correct UK country code: GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Follow these steps to enable the maxmind mod:
     ```nginx
     map $geoip2_data_country_iso_code $geo-whitelist {
         default no;
-        UK yes;
+        GB yes;
     }
 
     map $geoip2_data_country_iso_code $geo-blacklist {


### PR DESCRIPTION
It seems the actual geoip2_data_country_iso_code country code for the UK is GB (great britain).