### PR TITLE
Check existing permissions before calling chown in lsiown

### DIFF
--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -103,6 +103,7 @@ create_lsiown_alias() {
     # intentional tabs in the heredoc
     cat <<-EOF >/usr/bin/lsiown
 	#!/bin/bash
+	# Check ownership here
 	chown "\$@" || printf '**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
 	EOF
     chmod +x /usr/bin/lsiown


### PR DESCRIPTION
Blind chown-ing means the error message is shown even if the permissions are already correct. For example, if you have the directory mounted over nfs with root squashed, chown will always fail. But the permissions might be set correctly so it doesn't actually matter, and there's no need to display the message.

The simplest thing would just be to check the target for permissions, and if they're already set, to skip the chown call. We'd have to check for the `-R` argument and do it recursively, if necessary. There could be other arguments, but briefly scanning through [this search](https://github.com/search?q=org%3Alinuxserver+lsiown&type=code&p=1) showed only the one.

Another option might be to run `find` and only actually call chown on files that don't have the correct permission. This might be better for performance on large filesets, and if it failed, it would be a true failure. It would also require some argument parsing.
