### PR TITLE
Add /dev/kfd device

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 This mod adds the mesa libraries (v20.1+) needed for hardware encoding (VAAPI) on AMD GPUs to the Jellyfin Docker container (`latest` tag).
 
 To enable, you need to add the 2 following entries:
-- Device mapping for `/dev/dri`
-  - docker-compose: 
+- Device mapping for `/dev/dri` and `/dev/kfd`
+  - docker-compose:
     ```yaml
         devices:
           - /dev/dri:/dev/dri
+          - /dev/kfd:/dev/kfd
     ```
   - docker cli
     ```sh
     --device /dev/dri:/dev/dri
+    --device /dev/kfd:/dev/kfd
     ```
 - Environment Variable: `DOCKER_MODS=linuxserver/mods:jellyfin-amd`
   - docker-compose:

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-amd-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-amd-add-package/run
@@ -41,3 +41,37 @@ if "$install"; then
     echo "**** Adding mesa and rocm-opencl-runtime to package install list ****"
     echo "$pkgs" >> /mod-repo-packages-to-install.list
 fi
+
+FILES=$(find /dev/kfd -type c -print 2>/dev/null)
+
+for i in $FILES
+do
+    VIDEO_GID=$(stat -c '%g' "${i}")
+    VIDEO_UID=$(stat -c '%u' "${i}")
+    # check if user matches device
+    if id -u abc | grep -qw "${VIDEO_UID}"; then
+        echo "**** permissions for ${i} are good ****"
+    else
+        # check if group matches and that device has group rw
+        if id -G abc | grep -qw "${VIDEO_GID}" && [ $(stat -c '%A' "${i}" | cut -b 5,6) = "rw" ]; then
+            echo "**** permissions for ${i} are good ****"
+        # check if device needs to be added to video group
+        elif ! id -G abc | grep -qw "${VIDEO_GID}"; then
+            # check if video group needs to be created
+            VIDEO_NAME=$(getent group "${VIDEO_GID}" | awk -F: '{print $1}')
+            if [ -z "${VIDEO_NAME}" ]; then
+                VIDEO_NAME="video$(head /dev/urandom | tr -dc 'a-z0-9' | head -c4)"
+                groupadd "${VIDEO_NAME}"
+                groupmod -g "${VIDEO_GID}" "${VIDEO_NAME}"
+                echo "**** creating video group ${VIDEO_NAME} with id ${VIDEO_GID} ****"
+            fi
+            echo "**** adding ${i} to video group ${VIDEO_NAME} with id ${VIDEO_GID} ****"
+            usermod -a -G "${VIDEO_NAME}" abc
+        fi
+        # check if device has group rw
+        if [ $(stat -c '%A' "${i}" | cut -b 5,6) != "rw" ]; then
+            echo -e "**** The device ${i} does not have group read/write permissions, attempting to fix inside the container. ****"
+            chmod g+rw "${i}"
+        fi
+    fi
+done


### PR DESCRIPTION
According to https://github.com/RadeonOpenCompute/ROCm-docker, ROCm also requires /dev/kfd. On my machine with a Vega 56, OpenCL wouldn't work without it.