### PR TITLE
Don't create venv if pip is already installed

### DIFF
--- a/package-install.v1
+++ b/package-install.v1
@@ -4,14 +4,17 @@
 if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
     if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
-        if [[ -f /usr/bin/apt ]]; then
-            echo "python3-venv" >> /mod-repo-packages-to-install.list
-        elif [[ -f /sbin/apk ]]; then
-            echo "python3" >> /mod-repo-packages-to-install.list
-        elif [[ -f /usr/sbin/pacman ]]; then
-            echo "python" >> /mod-repo-packages-to-install.list
-        elif [[ -f /usr/bin/dnf ]]; then
-            echo "python3" >> /mod-repo-packages-to-install.list
+        if ! command -v python3; then
+            CREATE_VENV="true"
+            if [[ -f /usr/bin/apt ]]; then
+                echo "python3-venv" >> /mod-repo-packages-to-install.list
+            elif [[ -f /sbin/apk ]]; then
+                echo "python3" >> /mod-repo-packages-to-install.list
+            elif [[ -f /usr/sbin/pacman ]]; then
+                echo "python" >> /mod-repo-packages-to-install.list
+            elif [[ -f /usr/bin/dnf ]]; then
+                echo "python3" >> /mod-repo-packages-to-install.list
+            fi
         fi
     fi
 fi
@@ -42,7 +45,7 @@ if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
     if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
         echo "[mod-init] **** Installing all pip packages ****"
-        if ! command -v pip; then
+        if [[ ${CREATE_VENV} == "true" ]]; then
             echo "**** Creating venv ****"
             python3 -m venv /lsiopy
         fi

--- a/package-install.v1
+++ b/package-install.v1
@@ -42,7 +42,7 @@ if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
     if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
         echo "[mod-init] **** Installing all pip packages ****"
-        if [[ ! -d /lsiopy/bin ]]; then
+        if ! command -v pip; then
             echo "**** Creating venv ****"
             python3 -m venv /lsiopy
         fi
@@ -52,11 +52,7 @@ if [[ -f "/mod-pip-packages-to-install.list" ]]; then
             PIP_ARGS+=("-f" "https://wheel-index.linuxserver.io/ubuntu/")
         elif [[ -f /sbin/apk ]]; then
             ALPINE_VER=$(grep main /etc/apk/repositories | sed 's|.*alpine/v||' | sed 's|/main.*||')
-            if [[ "${ALPINE_VER}" = "3.14" ]]; then
-                PIP_ARGS+=("-f" "https://wheel-index.linuxserver.io/alpine/")
-            else
-                PIP_ARGS+=("-f" "https://wheel-index.linuxserver.io/alpine-${ALPINE_VER}/")
-            fi
+            PIP_ARGS+=("-f" "https://wheel-index.linuxserver.io/alpine-${ALPINE_VER}/")
         fi
         python3 -m pip install \
             "${PIP_ARGS[@]}" \


### PR DESCRIPTION
This handles the scenario where a non-venv python image has a python mod added to it, creating a venv and breaking the original app.

If python is already installed it's either in our venv (so we don't need to set one up) or it's in the default system location (so we don't want to set one up).

If python isn't installed at all then we assume it's safe to create the venv.

Also removes the alpine 3.14 check, as 3.14 doesn't pull in this script and I don't think anything uses the base any more anyway.