### PR TITLE
Change the python path according to swag updates

### DIFF
--- a/root/dashboard/www/index.php
+++ b/root/dashboard/www/index.php
@@ -47,7 +47,7 @@
     }
 
     function GetProxies() {
-        $output = shell_exec("/lsiopy/bin/python3 /dashboard/swag-proxies.py");
+        $output = shell_exec("if test -f /lsiopy/bin/python3; then /lsiopy/bin/python3 /dashboard/swag-proxies.py; else python3 /dashboard/swag-proxies.py; fi");
         $results = json_decode($output);
         $status = "";
         $index = 0;
@@ -100,7 +100,7 @@
     }
 
     function GetF2B() {
-        $output = shell_exec("/lsiopy/bin/python3 /dashboard/swag-f2b.py");
+        $output = shell_exec("if test -f /lsiopy/bin/python3; then /lsiopy/bin/python3 /dashboard/swag-f2b.py; else python3 /dashboard/swag-f2b.py; fi");
         $jails = json_decode($output, true);
         $status = "";
         $index = 0;

--- a/root/dashboard/www/index.php
+++ b/root/dashboard/www/index.php
@@ -47,7 +47,7 @@
     }
 
     function GetProxies() {
-        $output = shell_exec("python3 /dashboard/swag-proxies.py");
+        $output = shell_exec("/lsiopy/bin/python3 /dashboard/swag-proxies.py");
         $results = json_decode($output);
         $status = "";
         $index = 0;
@@ -100,7 +100,7 @@
     }
 
     function GetF2B() {
-        $output = shell_exec("python3 /dashboard/swag-f2b.py");
+        $output = shell_exec("/lsiopy/bin/python3 /dashboard/swag-f2b.py");
         $jails = json_decode($output, true);
         $status = "";
         $index = 0;


### PR DESCRIPTION
Fixed the broken proxy list in the dashboard due to swag updates.
Users with an older swag will have a broken proxy list in the dashboard if they restart the container without pulling the latest swag.