### PR TITLE
Make rffmpeg universally compatible

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-add-package/run
@@ -1,10 +1,24 @@
 #!/usr/bin/with-contenv bash
 
-for package in iputils-ping openssh-client python3-click python3-yaml wakeonlan; do
-    if ! dpkg -s "${package}" >/dev/null 2>&1; then
-        PACKAGES="${package} ${PACKAGES}"
+## Ubuntu
+if [ -f /usr/bin/apt ]; then
+    for package in iputils-ping openssh-client python3-click python3-yaml python3 wakeonlan; do
+        if ! dpkg -s "${package}" >/dev/null 2>&1; then
+            PACKAGES="${package} ${PACKAGES}"
+        fi
+    done
+fi
+# Alpine
+if [ -f /sbin/apk ]; then
+    if ! grep -qxF '@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing' /etc/apk/repositories; then
+        echo @testing https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
     fi
-done
+    for package in openssh py3-click py3-yaml python3 wol@testing; do
+        if ! apk info -e "${package}" >/dev/null 2>&1; then
+            PACKAGES="${package} ${PACKAGES}"
+        fi
+    done
+fi
 
 if [ -n "${PACKAGES}" ]; then
     echo "${PACKAGES}" >> /mod-repo-packages-to-install.list

--- a/root/usr/local/bin/wol_rffmpeg/wol
+++ b/root/usr/local/bin/wol_rffmpeg/wol
@@ -22,7 +22,15 @@ then
         if [ ! -z $WOL_NATIVE_PORT ]; then
             WOL_OPTIONS="$WOL_OPTIONS -p $WOL_NATIVE_PORT"
         fi
-        wakeonlan $WOL_OPTIONS $mac
+        # Alpine
+        if [ -f /sbin/apk ]; then
+                wol $WOL_OPTIONS $mac
+        fi
+        # Ubuntu
+        if [ -f /usr/bin/apt ]; then
+                wakeonlan $WOL_OPTIONS $mac
+        fi
+        #wakeonlan -i $RFFMPEG_HOST $mac
         echo "waiting $WOL_WAIT seconds for $RFFMPEG_HOST to wake"
         sleep $WOL_WAIT
 fi


### PR DESCRIPTION
rffmpeg is mostly used with jellyfin, however particularly with the introduction of joshuaboniface/rffmpeg#70 there are other uses, including with other linuxserver containers. Therefore it makes sense to make this image universal. Support has been added for alpine base images.

The branch and image may need to be renamed after this is merged.

WIP for now, I'd like to verify everything is working with the pipeline images.