### PR TITLE
Change lsiown to skip files owned by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 These files are used by Linuxserver build processes to handle mods in our images. Not for end-user consumption.
 
+* **08.09.23:** - Change lsiown to skip files that are already owned by the user.
 * **25.05.23:** - Add lscr.io support for mods.
 * **16.05.23:** - Add package installer.
 * **15.05.23:** - Add DOCKER_MODS_DEBUG env.

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -108,9 +108,27 @@ process_custom_services() {
 # Create our noisy chown alias to handle read-only/remote volumes
 create_lsiown_alias() {
     # intentional tabs in the heredoc
-    cat <<-EOF >/usr/bin/lsiown
+    cat <<-'EOF' >/usr/bin/lsiown
 	#!/bin/bash
-	chown "\$@" || printf '**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
+
+	OPTIONS=()
+	while getopts RcfvhHLP OPTION
+	do
+	    if [[ "${OPTION}" != "?" ]]; then
+	        OPTIONS+=("-${OPTION}")
+	    fi
+	done
+
+	shift $((OPTIND - 1))
+	OWNER=$1
+	IFS=: read -r USER GROUP <<< "${OWNER}"
+	if [[ -z "${GROUP}" ]]; then
+	    printf '**** Permissions could not be set. Group is missing or incorrect, expecting user:group. ****\n'
+	    exit 0
+	fi
+
+	PATH=("${@:2}")
+	/usr/bin/find "${PATH[@]}" \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf '**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
 	EOF
     chmod +x /usr/bin/lsiown
 }


### PR DESCRIPTION
Change lsiown to skip files already owned by the same user.

Will also fix [https://github.com/linuxserver/docker-calibre-web/issues/257](https://github.com/linuxserver/docker-calibre-web/issues/257).