### PR TITLE
Allow user to specify which version of rffmpeg to download

### DIFF
--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -20,7 +20,7 @@ jobs:
           echo "BASEIMAGE=${{ env.BASEIMAGE }}" >> $GITHUB_OUTPUT
           echo "MODNAME=${{ env.MODNAME }}" >> $GITHUB_OUTPUT
           # **** If the mod needs to be versioned, set the versioning logic below. Otherwise leave as is. ****
-          MOD_VERSION=$(curl -s https://api.github.com/repos/joshuaboniface/rffmpeg/commits/master | jq -rc '.sha')
+          MOD_VERSION=$(curl -s https://api.github.com/repos/joshuaboniface/rffmpeg/commits/master | jq -rc ".sha")
           echo "MOD_VERSION=${MOD_VERSION}" >> $GITHUB_OUTPUT
     outputs:
       GITHUB_REPO: ${{ steps.outputs.outputs.GITHUB_REPO }}

--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -20,7 +20,7 @@ jobs:
           echo "BASEIMAGE=${{ env.BASEIMAGE }}" >> $GITHUB_OUTPUT
           echo "MODNAME=${{ env.MODNAME }}" >> $GITHUB_OUTPUT
           # **** If the mod needs to be versioned, set the versioning logic below. Otherwise leave as is. ****
-          MOD_VERSION=""
+          MOD_VERSION=$(curl -s https://api.github.com/repos/joshuaboniface/rffmpeg/commits/master | jq -rc '.sha')
           echo "MOD_VERSION=${MOD_VERSION}" >> $GITHUB_OUTPUT
     outputs:
       GITHUB_REPO: ${{ steps.outputs.outputs.GITHUB_REPO }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG MOD_VERSION=master
 RUN \
   echo "**** grab rffmpeg ****" && \
   mkdir -p /root-layer/usr/local/bin/ && \
-  curl -o \
+  curl -fo \
     /root-layer/usr/local/bin/rffmpeg -L \
     "https://raw.githubusercontent.com/joshuaboniface/rffmpeg/${MOD_VERSION}/rffmpeg" && \
   chmod +x /root-layer/usr/local/bin/rffmpeg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,24 @@
 # syntax=docker/dockerfile:1
 
+FROM ghcr.io/linuxserver/baseimage-alpine:3.17 as buildstage
+
+ARG MOD_VERSION=master
+
+RUN \
+  echo "**** grab rffmpeg ****" && \
+  mkdir -p /root-layer/usr/local/bin/ && \
+  curl -o \
+    /root-layer/usr/local/bin/rffmpeg -L \
+    "https://raw.githubusercontent.com/joshuaboniface/rffmpeg/${MOD_VERSION}/rffmpeg" && \
+  chmod +x /root-layer/usr/local/bin/rffmpeg
+
+# copy local files
+COPY root/ /root-layer/
+
+## Single layer deployed image ##
 FROM scratch
 
 LABEL maintainer="junkman690"
 
-# copy local files
-COPY root/ /
+# Add files from buildstage
+COPY --from=buildstage /root-layer/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@
 
 FROM ghcr.io/linuxserver/baseimage-alpine:3.17 as buildstage
 
-ARG MOD_VERSION=master
+ARG MOD_VERSION
 
 RUN \
   echo "**** grab rffmpeg ****" && \
   mkdir -p /root-layer/usr/local/bin/ && \
+  MOD_VERSION=${MOD_VERSION:-master} && \
   curl -fo \
     /root-layer/usr/local/bin/rffmpeg -L \
     "https://raw.githubusercontent.com/joshuaboniface/rffmpeg/${MOD_VERSION}/rffmpeg" && \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ services:
       - RFFMPEG_WOL=api
       - RFFMPEG_HOST=transcode
       - RFFMPEG_HOST_MAC="12:ab:34:cd:ef:56"
+      - RFFMPEG_COMMIT_SHA=master # (optional) which commit of rffmpeg to download
       - WOL_API=192.168.1.5  #docker host IP
       - WOL_API_PORT=8431
       - WOL_WAIT=10  #time transcode host takes to start

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ services:
       - RFFMPEG_WOL=api
       - RFFMPEG_HOST=transcode
       - RFFMPEG_HOST_MAC="12:ab:34:cd:ef:56"
-      - RFFMPEG_COMMIT_SHA=master # (optional) which commit of rffmpeg to download
       - WOL_API=192.168.1.5  #docker host IP
       - WOL_API_PORT=8431
       - WOL_WAIT=10  #time transcode host takes to start

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-setup/run
@@ -13,17 +13,6 @@ else
     cp /defaults/rffmpeg.yml.sample /config/rffmpeg/rffmpeg.yml
 fi
 
-#Grab rffmpeg
-mkdir -p /usr/local/bin/
-echo "**** Grabbing rffmpeg from upstream ****"
-rm -rf /usr/local/bin/rffmpeg
-if [ ! -z "$RFFMPEG_COMMIT_SHA" ]; then
-    curl -L -o /usr/local/bin/rffmpeg https://raw.githubusercontent.com/joshuaboniface/rffmpeg/$RFFMPEG_COMMIT_SHA/rffmpeg
-else
-    curl -L -o /usr/local/bin/rffmpeg https://raw.githubusercontent.com/joshuaboniface/rffmpeg/master/rffmpeg
-fi
-chmod +x /usr/local/bin/rffmpeg
-
 ##Update rffmpeg.yml
 sed -i 's~#persist: "/run/shm"~persist: "/dev/shm"~' /config/rffmpeg/rffmpeg.yml
 sed -i 's~#state: "/var/lib/rffmpeg"~state: "/config/rffmpeg"~' /config/rffmpeg/rffmpeg.yml

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-setup/run
@@ -17,7 +17,11 @@ fi
 mkdir -p /usr/local/bin/
 echo "**** Grabbing rffmpeg from upstream ****"
 rm -rf /usr/local/bin/rffmpeg
-curl -L -o /usr/local/bin/rffmpeg https://raw.githubusercontent.com/joshuaboniface/rffmpeg/master/rffmpeg
+if [ ! -z "$RFFMPEG_COMMIT_SHA" ]; then
+    curl -L -o /usr/local/bin/rffmpeg https://raw.githubusercontent.com/joshuaboniface/rffmpeg/$RFFMPEG_COMMIT_SHA/rffmpeg
+else
+    curl -L -o /usr/local/bin/rffmpeg https://raw.githubusercontent.com/joshuaboniface/rffmpeg/master/rffmpeg
+fi
 chmod +x /usr/local/bin/rffmpeg
 
 ##Update rffmpeg.yml


### PR DESCRIPTION
I've been using this mod for the past few months and encountered breaking changes twice, without warning.
Unfortunately every time the jellyfin container is restarted, the latest rffmpeg is downloaded and I'm at the mercy of whatever changes have been made since I last ran.
I prefer my upgrades to always be intentional (not automatic) and for any changes to be acknowledged at a time I'm prepared to deal with them.

This PR add the ability to set the specific commit to download rffmpeg from.
This way I can opt in to changes when I chose to.