### PR TITLE
Fix lsiown edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 These files are used by Linuxserver build processes to handle mods in our images. Not for end-user consumption.
 
+* **14.09.23:** - Fix lsiown edge cases.
 * **08.09.23:** - Change lsiown to skip files that are already owned by the user.
 * **25.05.23:** - Add lscr.io support for mods.
 * **16.05.23:** - Add package installer.

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -111,11 +111,15 @@ create_lsiown_alias() {
     cat <<-'EOF' >/usr/bin/lsiown
 	#!/bin/bash
 
+	MAXDEPTH=("-maxdepth" "0")
 	OPTIONS=()
 	while getopts RcfvhHLP OPTION
 	do
-	    if [[ "${OPTION}" != "?" ]]; then
+	    if [[ "${OPTION}" != "?" && "${OPTION}" != "R" ]]; then
 	        OPTIONS+=("-${OPTION}")
+	    fi
+	    if [[ "${OPTION}" = "R" ]]; then
+	        MAXDEPTH=()
 	    fi
 	done
 
@@ -129,13 +133,7 @@ create_lsiown_alias() {
 
 	ERROR='**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
 	PATH=("${@:2}")
-
-	if [[ "${OPTIONS[*]}" =~ "-R" ]]; then
-		OPTIONS=( "${OPTIONS[@]/-R/-P}" )
-		/usr/bin/find "${PATH[@]}" \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
-	else
-		/usr/bin/find "${PATH[@]}" -maxdepth 0 \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
-	fi
+	/usr/bin/find "${PATH[@]}" "${MAXDEPTH[@]}" \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
 	EOF
     chmod +x /usr/bin/lsiown
 }

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -127,8 +127,15 @@ create_lsiown_alias() {
 	    exit 0
 	fi
 
+	ERROR='**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
 	PATH=("${@:2}")
-	/usr/bin/find "${PATH[@]}" \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf '**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
+
+	if [[ "${OPTIONS[*]}" =~ "-R" ]]; then
+		OPTIONS=( "${OPTIONS[@]/-R/-P}" )
+		/usr/bin/find "${PATH[@]}" \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
+	else
+		/usr/bin/find "${PATH[@]}" -maxdepth 0 \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
+	fi
 	EOF
     chmod +x /usr/bin/lsiown
 }


### PR DESCRIPTION
Fix lsiown edge cases:

1. `find` and `chown -R` both run recursively, removed `-R` before running to prevent it.
2. Prevent running recursively when `-R` was not given, by running `find` with `-maxdepth 0`.