### PR TITLE
Update universal-calibre to install required deps

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -61,6 +61,10 @@ if [ ! -L /usr/lib/x86_64-linux-gnu/libXcomposite.so.1 ]; then
     PACKAGES="libxcomposite1 ${PACKAGES}"
 fi
 
+if [ ! -L /usr/lib/x86_64-linux-gnu/libXrandr.so.2 ]; then
+    PACKAGES="libxrandr2 ${PACKAGES}"
+fi
+
 if [ -n "${PACKAGES}" ]; then
     echo "${PACKAGES}" >> /mod-repo-packages-to-install.list
     echo "**** Adding calibre dependencies to package install list ****"

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -57,6 +57,10 @@ if [ ! -L /usr/lib/x86_64-linux-gnu/libOpenGL.so.0 ]; then
     PACKAGES="libopengl0 ${PACKAGES}"
 fi
 
+if [ ! -L /usr/lib/x86_64-linux-gnu/libXcomposite.so.1 ]; then
+    PACKAGES="libxcomposite1 ${PACKAGES}"
+fi
+
 if [ -n "${PACKAGES}" ]; then
     echo "${PACKAGES}" >> /mod-repo-packages-to-install.list
     echo "**** Adding calibre dependencies to package install list ****"

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -50,7 +50,7 @@ if [ ! -L /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0 ]; then
 fi
 
 if [ ! -L /usr/lib/x86_64-linux-gnu/libnss3.so ]; then
-    PACKAGES="libnss3-dev ${PACKAGES}"
+    PACKAGES="libnss3 ${PACKAGES}"
 fi
 
 if [ ! -L /usr/lib/x86_64-linux-gnu/libOpenGL.so.0 ]; then

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -65,6 +65,10 @@ if [ ! -L /usr/lib/x86_64-linux-gnu/libXrandr.so.2 ]; then
     PACKAGES="libxrandr2 ${PACKAGES}"
 fi
 
+if [ ! -L /usr/lib/x86_64-linux-gnu/libXtst.so.6 ]; then
+    PACKAGES="libxtst6 ${PACKAGES}"
+fi
+
 if [ -n "${PACKAGES}" ]; then
     echo "${PACKAGES}" >> /mod-repo-packages-to-install.list
     echo "**** Adding calibre dependencies to package install list ****"

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -49,6 +49,10 @@ if [ ! -L /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0 ]; then
     PACKAGES="libxkbcommon0 ${PACKAGES}"
 fi
 
+if [ ! -L /usr/lib/x86_64-linux-gnu/libnss3.so ]; then
+    PACKAGES="libnss3-dev ${PACKAGES}"
+fi
+
 if [ ! -L /usr/lib/x86_64-linux-gnu/libOpenGL.so.0 ]; then
     PACKAGES="libopengl0 ${PACKAGES}"
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -61,6 +61,10 @@ if [ ! -L /usr/lib/x86_64-linux-gnu/libXcomposite.so.1 ]; then
     PACKAGES="libxcomposite1 ${PACKAGES}"
 fi
 
+if [ ! -L /usr/lib/x86_64-linux-gnu/libxkbfile.so.1 ]; then
+    PACKAGES="libxkbfile1 ${PACKAGES}"
+fi
+
 if [ ! -L /usr/lib/x86_64-linux-gnu/libXrandr.so.2 ]; then
     PACKAGES="libxrandr2 ${PACKAGES}"
 fi


### PR DESCRIPTION
resolves a missing dep in the mod
```
lazylibrarian  | Failed to import PyQt module: PyQt6.QtWebEngineCore with error: libnss3.so: cannot open shared object file: No such file or directory
lazylibrarian  | Creating symlinks...
lazylibrarian  |        Symlinking /app/calibre/ebook-device to /usr/bin/ebook-device
lazylibrarian  |        Symlinking /app/calibre/ebook-meta to /usr/bin/ebook-meta
lazylibrarian  |        Symlinking /app/calibre/ebook-convert to /usr/bin/ebook-convert
lazylibrarian  |        Symlinking /app/calibre/ebook-polish to /usr/bin/ebook-polish
lazylibrarian  |        Symlinking /app/calibre/markdown-calibre to /usr/bin/markdown-calibre
lazylibrarian  |        Symlinking /app/calibre/web2disk to /usr/bin/web2disk
lazylibrarian  |        Symlinking /app/calibre/calibre-server to /usr/bin/calibre-server
lazylibrarian  |        Symlinking /app/calibre/lrf2lrs to /usr/bin/lrf2lrs
lazylibrarian  |        Symlinking /app/calibre/lrs2lrf to /usr/bin/lrs2lrf
lazylibrarian  |        Symlinking /app/calibre/calibre-debug to /usr/bin/calibre-debug
lazylibrarian  |        Symlinking /app/calibre/calibredb to /usr/bin/calibredb
lazylibrarian  |        Symlinking /app/calibre/calibre-parallel to /usr/bin/calibre-parallel
lazylibrarian  |        Symlinking /app/calibre/calibre-customize to /usr/bin/calibre-customize
lazylibrarian  |        Symlinking /app/calibre/fetch-ebook-metadata to /usr/bin/fetch-ebook-metadata
lazylibrarian  |        Symlinking /app/calibre/calibre-smtp to /usr/bin/calibre-smtp
lazylibrarian  |        Symlinking /app/calibre/calibre to /usr/bin/calibre
lazylibrarian  |        Symlinking /app/calibre/lrfviewer to /usr/bin/lrfviewer
lazylibrarian  |        Symlinking /app/calibre/ebook-viewer to /usr/bin/ebook-viewer
lazylibrarian  |        Symlinking /app/calibre/ebook-edit to /usr/bin/ebook-edit
lazylibrarian  | Setting up command-line completion...
lazylibrarian  | Installing zsh completion to: /usr/share/zsh/vendor-completions/_calibre
lazylibrarian  | Failed to find directory to install bash completions, using default.
lazylibrarian  | Installing bash completion to: /usr/share/bash-completion/completions/
lazylibrarian  |
lazylibrarian  | ____________________ WARNING ____________________
lazylibrarian  | Setting up completion failed with error:
lazylibrarian  | __________________________________________________
lazylibrarian  |
lazylibrarian  |
lazylibrarian  |        Traceback (most recent call last):
lazylibrarian  |          File "calibre/linux.py", line 837, in setup_completion
lazylibrarian  |          File "calibre/linux.py", line 587, in write_completion
lazylibrarian  |          File "bypy-importer.py", line 279, in exec_module
lazylibrarian  |          File "calibre/gui2/tweak_book/main.py", line 12, in <module>
lazylibrarian  |          File "bypy-importer.py", line 279, in exec_module
lazylibrarian  |          File "calibre/ebooks/oeb/polish/check/css.py", line 11, in <module>
lazylibrarian  |        ImportError: cannot import name 'QWebEnginePage' from 'qt.webengine' (/app/calibre/lib/calibre-extensions/python-lib.bypy.frozen/qt/webengine.pyc)
```