### PR TITLE
Add support for new `swag_server_custom_directive` label

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This mod gives SWAG the ability to auto-detect running containers via labels and
 - `swag_url=containername.domain.com` - *optional* - overrides *server_name* (defaults to `containername.*`)
 - `swag_auth=authelia` - *optional* - enables auth methods (options are `authelia`, `authentik`, `ldap` and `http` for basic http auth)
 - `swag_auth_bypass=/api,/othersubfolder` - *optional* - bypasses auth for selected subfolders. Comma separated, no spaces.
+- `swag_server_custom_directive=custom_directive;` - *optional* - injects the label value as is into the server block of the generated conf. Must be a valid nginx directive, ending with a semi colon.
 
 
 In SWAG docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:universal-docker|linuxserver/mods:swag-auto-proxy` and either add a volume mapping for `/var/run/docker.sock:/var/run/docker.sock:ro`, or set an environment var `DOCKER_HOST=remoteaddress`.

--- a/root/app/auto-proxy.sh
+++ b/root/app/auto-proxy.sh
@@ -67,7 +67,8 @@ for CONTAINER in ${AUTO_GEN}; do
             echo "**** Overriding proto as ${swag_proto} for ${CONTAINER} ****"
         fi
         if [ -n "${swag_url}" ]; then
-            sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            SED_swag_url=$(sed -e 's/[&\\|]/\\&/g; s|$|\\|; $s|\\$||' <<<"${swag_url}")
+            sed -i "s|server_name .*|server_name ${SED_swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
             echo "**** Overriding url as ${swag_url} for ${CONTAINER} ****"
         fi
         if [ "${swag_auth}" == "authelia" ]; then
@@ -133,7 +134,8 @@ DUDE
         if [ -z "${swag_url}" ]; then
             swag_url="${CONTAINER}.*"
         fi
-        sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+        SED_swag_url=$(sed -e 's/[&\\|]/\\&/g; s|$|\\|; $s|\\$||' <<<"${swag_url}")
+        sed -i "s|server_name .*|server_name ${SED_swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
         echo "**** Setting url ${swag_url} for ${CONTAINER} ****"
         if [ "${swag_auth}" == "authelia" ]; then
             sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"

--- a/root/app/auto-proxy.sh
+++ b/root/app/auto-proxy.sh
@@ -13,7 +13,7 @@ else
             AUTO_GEN="${CONTAINER} ${AUTO_GEN}"
         else
             INSPECTION=$(docker inspect ${CONTAINER})
-            for VAR in swag_address swag_port swag_proto swag_url swag_auth swag_auth_bypass; do
+            for VAR in swag_address swag_port swag_proto swag_url swag_auth swag_auth_bypass swag_server_custom_directive; do
                 VAR_VALUE=$(echo ${INSPECTION} | jq -r ".[0].Config.Labels[\"${VAR}\"]")
                 if [ "${VAR_VALUE}" == "null" ]; then
                     VAR_VALUE=""
@@ -40,7 +40,7 @@ fi
 for CONTAINER in ${AUTO_GEN}; do
     INSPECTION=$(docker inspect ${CONTAINER})
     rm -rf "/auto-proxy/${CONTAINER}.conf"
-    for VAR in swag_address swag_port swag_proto swag_url swag_auth swag_auth_bypass; do
+    for VAR in swag_address swag_port swag_proto swag_url swag_auth swag_auth_bypass swag_server_custom_directive; do
         VAR_VALUE=$(echo ${INSPECTION} | jq -r ".[0].Config.Labels[\"${VAR}\"]")
         if [ "${VAR_VALUE}" == "null" ]; then
             VAR_VALUE=""
@@ -70,6 +70,11 @@ for CONTAINER in ${AUTO_GEN}; do
             SED_swag_url=$(sed -e 's/[&\\|]/\\&/g; s|$|\\|; $s|\\$||' <<<"${swag_url}")
             sed -i "s|server_name .*|server_name ${SED_swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
             echo "**** Overriding url as ${swag_url} for ${CONTAINER} ****"
+        fi
+        if [ -n "${swag_server_custom_directive}" ]; then
+            SED_swag_server_custom_directive=$(sed -e 's/[&\\|]/\\&/g; s|$|\\|; $s|\\$||' <<<"${swag_server_custom_directive}")
+            sed -i -e '/include.*ssl.conf;/a\' -e "    ${SED_swag_server_custom_directive}" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            echo "**** Adding custom directive from the swag_server_custom_directive label for ${CONTAINER} ****"
         fi
         if [ "${swag_auth}" == "authelia" ]; then
             sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
@@ -137,6 +142,11 @@ DUDE
         SED_swag_url=$(sed -e 's/[&\\|]/\\&/g; s|$|\\|; $s|\\$||' <<<"${swag_url}")
         sed -i "s|server_name .*|server_name ${SED_swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
         echo "**** Setting url ${swag_url} for ${CONTAINER} ****"
+        if [ -n "${swag_server_custom_directive}" ]; then
+            SED_swag_server_custom_directive=$(sed -e 's/[&\\|]/\\&/g; s|$|\\|; $s|\\$||' <<<"${swag_server_custom_directive}")
+            sed -i -e '/include.*ssl.conf;/a\' -e "    ${SED_swag_server_custom_directive}" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            echo "**** Adding custom directive from the swag_server_custom_directive label for ${CONTAINER} ****"
+        fi
         if [ "${swag_auth}" == "authelia" ]; then
             sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
             echo "**** Enabling Authelia for ${CONTAINER} ****"

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/finish
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/finish
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
-sed -i '/\/app\/auto-proxy.sh/d' /config/crontabs/root
+sed -i '/\/app\/auto-proxy.sh/d' /etc/crontabs/root
 rm -rf /etc/nginx/http.d/auto-proxy*.conf /config/nginx/proxy-confs/auto-proxy*.conf

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/run
@@ -12,8 +12,7 @@ rm -rf /auto-proxy
 mkdir /auto-proxy
 
 if ! grep -q "/app/auto-proxy.sh" /config/crontabs/root; then
-    echo "*       *       *       *       *       /app/auto-proxy.sh" >> /config/crontabs/root
-    cp /config/crontabs/root /etc/crontabs/root
+    echo "*       *       *       *       *       /app/auto-proxy.sh" >> /etc/crontabs/root
 fi
 
 /app/auto-proxy.sh

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/run
@@ -11,7 +11,7 @@ cp /defaults/auto-proxy-readme /etc/nginx/http.d/auto-proxy-readme
 rm -rf /auto-proxy
 mkdir /auto-proxy
 
-if ! grep -q "/app/auto-proxy.sh" /config/crontabs/root; then
+if ! grep -q "/app/auto-proxy.sh" /etc/crontabs/root; then
     echo "*       *       *       *       *       /app/auto-proxy.sh" >> /etc/crontabs/root
 fi
 


### PR DESCRIPTION
- Inject a custom directive into the server block via `swag_server_custom_directive` label
- Make compatible with upcoming cron changes
- Sanitize `swag_url` sed replace

closes #764 