### PR TITLE
[code-server-nodejs] Update repo, drop support for node 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This mod adds a nodejs dev environment to code-server/openvscode-server, to be i
 
 In code-server/openvscode-server docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:code-server-nodejs`
 
-You can define the nodejs major version to be installed via setting the environment variable `NODEJS_MOD_VERSION` (accepts `16`, `18`, etc. defaults to `14`).
+You can define the nodejs major version to be installed via setting the environment variable `NODEJS_MOD_VERSION` (accepts `16`, `18`, 20, etc. Minimum of `16`, defaults to `16`).
 
 If adding multiple mods, enter them in an array separated by `|`, such as `DOCKER_MODS=linuxserver/mods:code-server-nodejs|linuxserver/mods:code-server-mod2`

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-code-server-nodejs-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-code-server-nodejs-add-package/run
@@ -1,11 +1,10 @@
 #!/usr/bin/with-contenv bash
 
 echo "**** installing nodejs dev environment ****"
-source /etc/lsb-release
-NODEJS_MOD_VERSION=${NODEJS_MOD_VERSION:-14}
+NODEJS_MOD_VERSION=${NODEJS_MOD_VERSION:-16}
 if [[ ! -f "/etc/apt/sources.list.d/nodesource.list" ]]; then
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null
-    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_MOD_VERSION}.x ${DISTRIB_CODENAME} main" \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_MOD_VERSION}.x nodistro main" \
         > /etc/apt/sources.list.d/nodesource.list
 fi
 if [[ ! -f "/etc/apt/sources.list.d/yarn.list" ]]; then


### PR DESCRIPTION
As per https://deb.nodesource.com/

New repo structure no longer supports v14 as it's long EOL. v16 still works even though it's just gone EOL.

Closes #779 