### PR TITLE
Fix issue with logs that contains space in the path

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bash
 
 if [ -n "${LOGS_TO_STDOUT}" ]; then
-    IFS='|' read -ra PATH_ARRAY <<< "$LOGS_TO_STDOUT"
-    echo "Executing: tail -F ${PATH_ARRAY[@]}"
-    tail -F "${PATH_ARRAY[@]}"
+    IFS='|' read -ra TAIL_LOGS <<< "$LOGS_TO_STDOUT"
+    echo "Executing: tail -F ${TAIL_LOGS[@]}"
+    tail -F "${TAIL_LOGS[@]}"
 else
     echo "**** Env var LOGS_TO_STDOUT is not set, sleeping ****"
 fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
@@ -3,7 +3,7 @@
 if [ -n "${LOGS_TO_STDOUT}" ]; then
     TAIL_LOGS=$(echo "$LOGS_TO_STDOUT" | sed 's#|# #g')
     echo "Executing: tail -F $TAIL_LOGS"
-    tail -F $TAIL_LOGS
+    tail -F "$TAIL_LOGS"
 else
     echo "**** Env var LOGS_TO_STDOUT is not set, sleeping ****"
 fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
@@ -1,9 +1,9 @@
 #!/usr/bin/with-contenv bash
 
 if [ -n "${LOGS_TO_STDOUT}" ]; then
-    TAIL_LOGS=$(echo "$LOGS_TO_STDOUT" | sed 's#|# #g')
-    echo "Executing: tail -F $TAIL_LOGS"
-    tail -F "$TAIL_LOGS"
+    IFS='|' read -ra PATH_ARRAY <<< "$LOGS_TO_STDOUT"
+    echo "Executing: tail -F ${PATH_ARRAY[@]}"
+    tail -F "${PATH_ARRAY[@]}"
 else
     echo "**** Env var LOGS_TO_STDOUT is not set, sleeping ****"
 fi


### PR DESCRIPTION
Fix issue with logs that contains space in the path: wrap tail argument in quotes to prevent the faulty behavior as per https://stackoverflow.com/a/43793896