### PR TITLE
[jellyfin-amd] fix: add missing package for OpenCL

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-amd-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-amd-add-package/run
@@ -22,7 +22,7 @@ if [ ! -f "/etc/apt/sources.list.d/amdgpu-focal.list" ]; then
 fi
 
 
-pkgs='mesa-vdpau-drivers mesa-va-drivers mesa-vdpau-drivers libdrm-radeon1 rocm-opencl-runtime'
+pkgs='mesa-vdpau-drivers mesa-va-drivers mesa-vdpau-drivers mesa-opencl-icd libdrm-radeon1 rocm-opencl-runtime'
 
 install=false
 for pkg in $pkgs; do


### PR DESCRIPTION
Tagging the maintainer: @PascalMinder
