### PR TITLE
build: change upstream to a maintained fork of transmission-web-control

### DIFF
--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -20,7 +20,7 @@ jobs:
           echo "BASEIMAGE=${{ env.BASEIMAGE }}" >> $GITHUB_OUTPUT
           echo "MODNAME=${{ env.MODNAME }}" >> $GITHUB_OUTPUT
           # **** If the mod needs to be versioned, set the versioning logic below. Otherwise leave as is. ****
-          MOD_VERSION=$(curl -s https://api.github.com/repos/ronggang/transmission-web-control/releases/latest | jq -rc ".tag_name")
+          MOD_VERSION=$(curl -s https://api.github.com/repos/transmission-web-control/transmission-web-control/releases/latest | jq -rc ".tag_name")
           echo "MOD_VERSION=${MOD_VERSION}" >> $GITHUB_OUTPUT
     outputs:
       GITHUB_REPO: ${{ steps.outputs.outputs.GITHUB_REPO }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,16 @@ RUN \
   echo "**** grab transmission-web-control ****" && \
   mkdir -p /root-layer/themes && \
   if [ -z ${MOD_VERSION} ]; then \
-    MOD_VERSION=$(curl -s "https://api.github.com/repos/ronggang/transmission-web-control/releases/latest" \
+    MOD_VERSION=$(curl -s "https://api.github.com/repos/transmission-web-control/transmission-web-control/releases/latest" \
     | jq -rc ".tag_name"); \
   fi && \
   curl -o \
     /tmp/transmission-web-control.tar.gz -L \
-    "https://github.com/ronggang/transmission-web-control/archive/refs/tags/${MOD_VERSION}.tar.gz" && \
+    "https://github.com/transmission-web-control/transmission-web-control/releases/download/${MOD_VERSION}/dist.tar.gz" && \
   mkdir -p /root-layer/themes/transmission-web-control && \
   tar xzf \
     /tmp/transmission-web-control.tar.gz -C \
-    /root-layer/themes/transmission-web-control \
-    $(tar tf /tmp/transmission-web-control.tar.gz | grep -E "^[^/]+/src") --strip-components=2
+    /root-layer/themes/transmission-web-control --strip-components=2
 
 # copy local files
 COPY root/ /root-layer/


### PR DESCRIPTION
Currently the original project is not under active development, so we change the upstream to a maintained fork of it.