### PR TITLE
transmission-floodui: make config persistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.17 as buildstage
+FROM ghcr.io/linuxserver/baseimage-alpine:3.19 as buildstage
 
 ARG MOD_VERSION
 
@@ -16,7 +16,8 @@ RUN \
   mkdir -p /root-layer/themes/flood-for-transmission && \
   tar xzf \
     /tmp/flood.tar.gz -C \
-    /root-layer/themes/flood-for-transmission --strip-components=1
+    /root-layer/themes/flood-for-transmission --strip-components=1 && \
+  ln -s /config/themes/flood-for-transmission/config.json /root-layer/themes/flood-for-transmission/config.json
 
 # copy local files
 COPY root/ /root-layer/

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-transmission-floodui-install/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-transmission-floodui-install/run
@@ -1,6 +1,15 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+mkdir -p /config/themes/flood-for-transmission
+if [ ! -f /config/themes/flood-for-transmission/config.json ]; then
+    cp /themes/flood-for-transmission/config.json.defaults /config/themes/flood-for-transmission/config.json
+fi
+# Keep an up-to-date copy of the defaults in case there are breaking changes to the config.json and the user needs to manually update
+cp /themes/flood-for-transmission/config.json.defaults /config/themes/flood-for-transmission/config.json.defaults
+
 printf "/themes/flood-for-transmission" > /var/run/s6/container_environment/TRANSMISSION_WEB_HOME
 
-lsiown -R abc:abc /themes
+lsiown -R abc:abc \
+    /themes \
+    /config/themes/flood-for-transmission


### PR DESCRIPTION
also provide defaults file updated with upstream changes in case there are breaking changes to the config file and the user needs to manually update

closes #807 