### PR TITLE
Add optional custom data root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In the container's docker arguments,
 * Set an environment variable `DOCKER_MODS=linuxserver/mods:universal-docker-in-docker`
 * Set the `privileged` option for the container
 
-Docker data root will reside under `/config/var/lib/docker`.
+Docker data root will reside under `/config/var/lib/docker` by default, this is configurable by setting `MODS_DIND_PERSISTENCE` to the wanted path.
 On amd64, QEMU will be enabled on container start.
 
 If adding multiple mods, enter them in an array separated by `|`, such as `DOCKER_MODS=linuxserver/mods:universal-docker-in-docker|linuxserver/mods:universal-mod2`

--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-docker-in-docker/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-docker-in-docker/run
@@ -31,4 +31,4 @@ fi
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "docker version" \
         2>&1 /usr/local/bin/dockerd \
-            --data-root "/config/var/lib/docker"
+            --data-root "${MODS_DIND_PERSISTENCE:-/config/var/lib/docker}"


### PR DESCRIPTION
Allows for changing the default data root path, useful for backups or recursive chowns of /config