### PR TITLE
Add `-c0` flag to prevent showing stale log entries

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-mod-universal-stdout-logs/run
@@ -2,8 +2,8 @@
 
 if [ -n "${LOGS_TO_STDOUT}" ]; then
     IFS='|' read -ra TAIL_LOGS <<< "$LOGS_TO_STDOUT"
-    echo "Executing: tail -F ${TAIL_LOGS[@]}"
-    tail -F "${TAIL_LOGS[@]}"
+    echo "Executing: tail -Fc0 ${TAIL_LOGS[@]}"
+    tail -Fc0 "${TAIL_LOGS[@]}"
 else
     echo "**** Env var LOGS_TO_STDOUT is not set, sleeping ****"
 fi


### PR DESCRIPTION
Add `tail -c0` flag to prevent showing stale log entries in the log as the container starts.