### PR TITLE
force create venv if pip packages are to be installed

### DIFF
--- a/package-install.v1
+++ b/package-install.v1
@@ -1,11 +1,28 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# Version 1
+# 2024-03-26 - Initial Version
+PKG_SCRIPT_VER="3.20240326"
+
+write_mod_info() {
+    local MSG=$*
+    echo "[pkg-install-init] **** $MSG ****"
+}
+
+write_mod_debug() {
+    local MSG=$*
+    if [[ ${DOCKER_MODS_DEBUG,,} = "true" ]]; then echo "[pkg-install-init] (DEBUG) $MSG"; fi
+}
+
+write_mod_debug "Package install script version ${MOD_SCRIPT_VER}"
+
 if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
     if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
-        if [[ ! -e /lsiopy/bin/python3 ]]; then
+        if [[ "$(command -v python3)" != "/lsiopy/bin/python3" ]]; then
             CREATE_VENV="true"
+            write_mod_debug "Marking venv for creation and adding python os dependencies to install list."
             if [[ -f /usr/bin/apt ]]; then
                 echo "python3-venv" >> /mod-repo-packages-to-install.list
             elif [[ -f /sbin/apk ]]; then
@@ -15,14 +32,21 @@ if [[ -f "/mod-pip-packages-to-install.list" ]]; then
             elif [[ -f /usr/bin/dnf ]]; then
                 echo "python3" >> /mod-repo-packages-to-install.list
             fi
+        else
+            write_mod_debug "Venv at /lsiopy is already active"
         fi
+    else
+        write_mod_debug "No pip packages identified in install list, skipping."
     fi
+else
+    write_mod_debug "No pip packages defined for install, skipping."
 fi
 
 if [[ -f "/mod-repo-packages-to-install.list" ]]; then
     IFS=' ' read -ra REPO_PACKAGES <<< "$(tr '\n' ' ' < /mod-repo-packages-to-install.list)"
     if [[ ${#REPO_PACKAGES[@]} -ne 0 ]] && [[ ${REPO_PACKAGES[*]} != "" ]]; then
-        echo "[mod-init] **** Installing all mod packages ****"
+        write_mod_info "Installing all mod packages"
+        write_mod_debug "Defined packages: ${REPO_PACKAGES[@]}"
         if [[ -f /usr/bin/apt ]]; then
             export DEBIAN_FRONTEND="noninteractive"
             apt-get update
@@ -38,17 +62,22 @@ if [[ -f "/mod-repo-packages-to-install.list" ]]; then
             dnf install -y --setopt=install_weak_deps=False --best \
                 "${REPO_PACKAGES[@]}"
         fi
+    else
+        write_mod_debug "No os packages identified in install list, skipping."
     fi
+else
+    write_mod_debug "No os packages defined for install, skipping."
 fi
 
 if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
     if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
-        echo "[mod-init] **** Installing all pip packages ****"
+        write_mod_info "Installing all pip packages"
         if [[ ${CREATE_VENV} == "true" ]]; then
-            echo "**** Creating venv ****"
+            write_mod_info "Creating venv"
             python3 -m venv /lsiopy
         fi
+        write_mod_debug "Updating/installing pip, wheel and setuptools."
         python3 -m pip install -U pip wheel setuptools
         PIP_ARGS=()
         if [[ -f /usr/bin/apt ]] && grep -q 'ID=ubuntu' /etc/os-release; then
@@ -57,12 +86,15 @@ if [[ -f "/mod-pip-packages-to-install.list" ]]; then
             ALPINE_VER=$(grep main /etc/apk/repositories | sed 's|.*alpine/v||' | sed 's|/main.*||')
             PIP_ARGS+=("-f" "https://wheel-index.linuxserver.io/alpine-${ALPINE_VER}/")
         fi
+        write_mod_debug "Installing defined pip packages: ${PIP_PACKAGES[@]}"
+        write_mod_debug "Using pip args ${PIP_ARGS[@]}"
         python3 -m pip install \
             "${PIP_ARGS[@]}" \
             "${PIP_PACKAGES[@]}"
     fi
 fi
 
+write_mod_debug "Deleting temporary install lists for os and pip packages."
 rm -rf \
     /mod-repo-packages-to-install.list \
     /mod-pip-packages-to-install.list

--- a/package-install.v1
+++ b/package-install.v1
@@ -4,7 +4,7 @@
 if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"
     if [[ ${#PIP_PACKAGES[@]} -ne 0 ]] && [[ ${PIP_PACKAGES[*]} != "" ]]; then
-        if ! command -v python3; then
+        if [[ ! -e /lsiopy/bin/python3 ]]; then
             CREATE_VENV="true"
             if [[ -f /usr/bin/apt ]]; then
                 echo "python3-venv" >> /mod-repo-packages-to-install.list

--- a/package-install.v1
+++ b/package-install.v1
@@ -15,7 +15,7 @@ write_mod_debug() {
     if [[ ${DOCKER_MODS_DEBUG,,} = "true" ]]; then echo "[pkg-install-init] (DEBUG) $MSG"; fi
 }
 
-write_mod_debug "Package install script version ${MOD_SCRIPT_VER}"
+write_mod_debug "Package install script version ${PKG_SCRIPT_VER}"
 
 if [[ -f "/mod-pip-packages-to-install.list" ]]; then
     IFS=' ' read -ra PIP_PACKAGES <<< "$(tr '\n' ' ' < /mod-pip-packages-to-install.list)"


### PR DESCRIPTION
Currently if python is already installed in the image, we don't create a venv but as more distros are switching to python versions after PEP 668, it is causing errors.

This PR will force create venv if `INSTALL_PIP_PACKAGES` var is defined.

Alpine, noble and debian already do not work without venv when pip packages are defined for install. Jammy currently works, but will break once the images are based on noble.

Without this PR, no images with python installed but no venv will work with the universal package install script to install pip packages once we move to noble.

With this PR, certain python based apps may face issues when the user custom installs pip packages and a venv is force created, but that's a very small risk as the same conditions will cause breakage after jammy --> noble rebase even without this PR.

Tested 2 images that fit that criteria, transmission and deluge, with venv created and they worked fine.