### PR TITLE
let lsiown ignore broken symlinks

### DIFF
--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -5,7 +5,8 @@
 
 # Version 3
 # 2022-09-25 - Initial Release
-MOD_SCRIPT_VER="3.20240225"
+# 2024-04-13 - Let lsiown ignore broken symlinks (requires gnu find)
+MOD_SCRIPT_VER="3.20240413"
 
 # Define custom folder paths
 SCRIPTS_DIR="/custom-cont-init.d"

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -132,7 +132,7 @@ create_lsiown_alias() {
 
 	ERROR='**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****\n**** The app may not work properly and we will not provide support for it. ****\n'
 	PATH=("${@:2}")
-	/usr/bin/find "${PATH[@]}" "${MAXDEPTH[@]}" \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
+	/usr/bin/find "${PATH[@]}" "${MAXDEPTH[@]}" ! -xtype l \( ! -group "${GROUP}" -o ! -user "${USER}" \) -exec chown "${OPTIONS[@]}" "${USER}":"${GROUP}" {} + || printf "${ERROR}"
 	EOF
     chmod +x /usr/bin/lsiown
 }


### PR DESCRIPTION
Currently, if lsiown encounters a broken symlink (target not exists), it incorrectly prints the error about remote mounts and such.

This affects SWAG on a fresh install because the certs aren't generated yet.

This PR attempts to ignore broken symlinks in lsiown.

The downside is that the new arg `-xtype` only works with gnu find and not busybox so this PR would require adding the package `findutils` on alpine baseimage.