### PR TITLE
lidarr: flac2mp3 release 2.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Development Container info:
       - Dev/test release: `DOCKER_MODS=thecaptain989/lidarr-flac2mp3:latest`
 
       *Example Docker Compose YAML Configuration*  
+
       ```yaml
       version: "2.1"
       services:
@@ -42,6 +43,7 @@ Development Container info:
       ```  
 
       *Example Docker Run Command*  
+
        ```shell
        docker run -d \
          --name=lidarr \
@@ -70,23 +72,21 @@ Development Container info:
 
    This will use the defaults to create a 320Kbps MP3 file.
 
-   *For any other setting, you **must** use one of the supported methods to pass arguments to the script.  See the [Syntax](./README.md#syntax) section below.*
+   *For any other setting, you **must** use one of the supported methods to pass arguments to the script.  See the [Command-Line Syntax](./README.md#command-line-syntax) section below.*
 
-## Usage
-New file(s) will be placed in the same directory as the original FLAC file(s) (unless redirected with the `--output` option below) and have the same owner and permissions. Existing files with the same track name will be overwritten.
+# Usage
+New file(s) will be placed in the same directory as the original FLAC file(s) (unless redirected with the `--output` option below) with permissions preserved. Existing files with the same track name will be overwritten. Owner is preserved if the script is executed as root.
 
 By default, if you've configured Lidarr's **Recycle Bin** path correctly, the original audio file will be moved there.  
 ![danger] **NOTE:** If you have *not* configured the Recycle Bin, the original FLAC audio file(s) will be deleted and permanently lost.  This behavior may be modified with the `--keep-file` option.
 
-### Syntax
->**Note:** The _Arguments_ field for Custom Scripts was removed in Lidarr release [v0.7.0.1347](https://github.com/lidarr/Lidarr/commit/b9d240924f8965ebb2c5e307e36b810ae076101e "Lidarr commit notes") due to security concerns.
+## Command-Line Syntax
+>**Note:** The *Arguments* field for Custom Scripts was removed in Lidarr release [v0.7.0.1347](https://github.com/lidarr/Lidarr/commit/b9d240924f8965ebb2c5e307e36b810ae076101e "Lidarr commit notes") due to security concerns.
 
-To supply arguments to the script, you **must** either use one of the **[included wrapper scripts](./README.md#included-wrapper-scripts)**, create a **[custom wrapper script](./README.md#example-wrapper-script)**, or set the `FLAC2MP3_ARGS` **[environment variable](./README.md#environment-variable)**.
+### Options and Arguments
+The script may be called with optional command-line arguments.
 
-#### Command Line Options and Arguments
-The script may be called with optional command line arguments.
-
-The syntax for the command line is:  
+The syntax for the command-line is:  
 `flac2mp3 [{-b|--bitrate} <bitrate> | {-v|--quality} <quality> | {-a|--advanced} "<options>" {-e|--extension} <extension>] [{-f|--file} <audio_file>] [{-k|--keep-file}] [{-o|--output} <directory>] [{-r|--regex} '<regex>'] [{-t|--tags} <taglist>] [{-l|--log} <log_file>] [{-d|--debug} [<level>]]`  
 
 Where:
@@ -95,7 +95,7 @@ Option|Argument|Description
 ---|---|---
 -b, --bitrate|\<bitrate\>|Sets the output quality in constant bits per second (CBR).<br/>Examples: 160k, 240k, 300000<br/>**Note:** May not be specified with `-v`, `-a`, or `-e`.
 -v, --quality|\<quality\>|Sets the output variable bit rate (VBR).<br/>Specify a value between 0 and 9, with 0 being the highest quality.<br/>See the [FFmpeg MP3 Encoding Guide](https://trac.ffmpeg.org/wiki/Encode/MP3) for more details.<br/>**Note:** May not be specified with `-b`, `-a`, or `-e`.
--a, --advanced|\"\<options\>\"|Advanced ffmpeg options.<br/>The specified `options` replace all script defaults and are sent directly to ffmpeg.<br/>The `options` value must be enclosed in quotes.<br/>See [FFmpeg Options](https://ffmpeg.org/ffmpeg.html#Options) for details on valid options, and [Guidelines for high quality audio encoding](https://trac.ffmpeg.org/wiki/Encode/HighQualityAudio) for suggested usage.<br/>**Note:** Requires the `-e` option to also be specified. May not be specified with `-v` or `-b`.<br/>![warning] **WARNING:** You must specify an audio codec (by including a `-c:a <codec>` ffmpeg option) or the resulting file will contain no audio!<br/>![warning] **WARNING:** Invalid `options` could result in script failure!
+-a, --advanced<!-- markdownlint-disable-line MD013 -->|\"\<options\>\"|Advanced ffmpeg options.<br />The specified `options` replace all script defaults and are sent directly to ffmpeg.<br/>The `options` value must be enclosed in quotes.<br/>See [FFmpeg Options](https://ffmpeg.org/ffmpeg.html#Options) for details on valid options, and [Guidelines for high quality audio encoding](https://trac.ffmpeg.org/wiki/Encode/HighQualityAudio) for suggested usage.<br/>**Note:** Requires the `-e` option to also be specified. May not be specified with `-v` or `-b`.<br/>![warning] **WARNING:** You must specify an audio codec (by including a `-c:a <codec>` ffmpeg option) or the resulting file will contain no audio!<br/>![warning] **WARNING:** Invalid `options` could result in script failure!
 -e, --extension|\<extension\>|Sets the output file extension.<br/>The extension may be prefixed by a dot (".") or not.<br/>Example: .ogg<br/>**Note:** Requires the `-a` option to also be specified. May not be specified with `-v` or `-b`.
 -f, --file|<audio_file>|If included, the script enters **[Batch Mode](./README.md#batch-mode)** and converts the specified audio file.<br/>![warning] **WARNING:** Do not use this argument when called from Lidarr!
 -o, --output|\<directory\>|Converted audio file(s) are saved to `directory` instead of being located in the same directory as the source audio file.<br/>The path will be created if it does not exist.
@@ -110,29 +110,36 @@ Option|Argument|Description
 If neither `-b`, `-v`, `-a`, or `-e` options are specified, the script will default to a constant 320Kbps MP3.
 
 #### Technical notes on advanced options
-The `-a` option effectively makes the script a generic wrapper for ffmpeg.  FFmpeg is executed once per track with only the loglevel, input filename, and output filename being set.  All other options are passed unparsed to the command line.  
+The `-a` option effectively makes the script a generic wrapper for ffmpeg.  FFmpeg is executed once per track with only the loglevel, input filename, and output filename being set.  All other options are passed unparsed to the command-line.  
 
 The exact format of the executed ffmpeg command is:
-```
+
+```shell
 ffmpeg -loglevel error -nostdin -i "input.flac" ${options} "output.${extension}"
 ```
 
-#### Technical notes on regex
-By default, the script only matches and interacts with FLAC files (specifically, files ending in ".flac"). The `-r` option allows the script to match on a user specified regular expression (i.e. "regex") pattern. 
+#### Technical notes on regular expressions
+<!-- textlint-disable terminology -->
 
-Files are passed to the script with the full Linux path intact. (Ex: `/path/to/audio/a-ha/Hunting High and Low/01 Take on Me.mp3`).  Craft your regex with this in mind.
+By default, the script only matches and interacts with FLAC files (specifically, files ending in ".flac"). The `-r` option allows the script to match on a user specified regular expression (i.e. "regex") pattern.
 
-![warning] **NOTE:** Escaping special regex characters (like a dot `.`) requires a double backslash or a character class. A character class (i.e. `[.]`) is recommended because backslashes can be stripped by the bash shell and getting this right can be confusing.
+<!-- textlint-enable -->
+
+Files are passed to the script with the full Linux path intact. (Ex: `/path/to/audio/a-ha/Hunting High and Low/01 Take on Me.mp3`).  Craft your regular expression with this in mind.
+
+![warning] **NOTE:** Escaping special regular expression characters (like a dot `.`) requires a double backslash or a character class. A character class (i.e. `[.]`) is recommended because backslashes can be stripped by the bash shell and getting this right can be confusing.
 
 For example, to convert all audio files to AAC audio files, use the following options:  
-```
+
+```shell
 -a "-y -map 0 -c:a aac -b:a 240k -c:v copy" -e m4a --regex '[.][^.]*$'
 ```
 
-Regular expression syntax is beyond the scope of this document.  See this [tutorial](https://www.regular-expressions.info/tutorial.html "Regular Expressions Tutorial") for more information. Regex patterns may be tested [here](http://regexstorm.net/tester "regex tester").
+Regular expression syntax is beyond the scope of this document.  See this [tutorial](https://www.regular-expressions.info/tutorial.html "Regular Expressions Tutorial") for more information. Regular expression patterns may be tested [here](http://regexstorm.net/tester "regex tester").
 
-### Examples
-```
+## Examples
+
+```shell
 -b 320k        # Output 320 kbit/s MP3 (non-VBR; same as default behavior)
 -v 0           # Output variable bitrate MP3, VBR 220-260 kbit/s
 -d -b 160k     # Enable debugging level 1, and output a 160 kbit/s MP3
@@ -150,11 +157,14 @@ Regular expression syntax is beyond the scope of this document.  See this [tutor
                # Place the converted file(s) in the specified directory and do not delete the original audio file(s)
 ```
 
-#### Included Wrapper Scripts
+## Wrapper Scripts
+To supply arguments to the script, you must either use one of the included wrapper scripts, create a custom wrapper script, or set the `FLAC2MP3_ARGS` [environment variable](./README.md#environment-variable).
+
+### Included Wrapper Scripts
 For your convenience, several wrapper scripts are included in the `/usr/local/bin/` directory.  
 You may use any of these scripts in place of the `flac2mp3.sh` mentioned in the [Installation](./README.md#installation) section above.
 
-```
+```shell
 flac2mp3-debug.sh        # Enable debugging, level 1
 flac2mp3-debug-2.sh      # Enable debugging, level 2
 flac2mp3-vbr.sh          # Use variable bit rate MP3, quality 0
@@ -162,14 +172,17 @@ flac2opus.sh             # Convert to Opus format using .opus extension, 192 kbi
 flac2alac.sh             # Convert to Apple Lossless using an .m4a extension
 ```
 
-#### Example Wrapper Script
+### Example Wrapper Script
 To configure an entry from the [Examples](./README.md#examples) section above, create and save a file called `flac2mp3-custom.sh` to `/config` containing the following text:
+
 ```shell
 #!/bin/bash
 
 . /usr/local/bin/flac2mp3.sh -d -b 160k
 ```
+
 Make it executable:
+
 ```shell
 chmod +x /config/flac2mp3-custom.sh
 ```
@@ -178,16 +191,18 @@ Then put `/config/flac2mp3-custom.sh` in the **Path** field in place of `/usr/lo
 
 >**Note:** If you followed the Linuxserver.io recommendations when configuring your container, the `/config` directory will be mapped to an external storage location.  It is therefore recommended to place custom scripts in the `/config` directory so they will survive container updates, but they may be placed anywhere that is accessible by Lidarr.
 
-### Environment Variable
+## Environment Variable
 The `flac2mp3.sh` script also allows the use of arguments provided by the `FLAC2MP3_ARGS` environment variable. This allows advanced use cases without having to provide a custom script.
 
 For example, the following value in your `docker run` command would convert any .mp3 to Opus:
-```
+
+```shell
 -e FLAC2MP3_ARGS='-a "-vn -c:a libopus -b:a 192k" -e .opus -r "[.]mp3$"'
 ```
 
-Make sure to correctly use quotes and/or escape special characters when using this method. (See [regex notes](./README.md#technical-notes-on-regex) above.)  
+Make sure to correctly use quotes and/or escape special characters when using this method. (See [regular expression notes](./README.md#technical-notes-on-regular-expressions) above.)  
 In Docker Compose, the previous command would need an extra `$` to match the end-of-line:
+
 ```yaml
 environment:
   - FLAC2MP3_ARGS=-a "-vn -c:a libopus -b:a 192k" -e .opus -r '[.]mp3$$'
@@ -196,40 +211,31 @@ environment:
 *Example Synology Configuration*  
 ![flac2mp3](.assets/lidarr-synology-2.png "Synology container settings")
 
->**NOTE:** The environment variable settings are _only_ used when **no** command line arguments are present. **Any** command line argument will disable the use of the environment variable.
+>**NOTE:** The environment variable settings are *only* used when **no** command-line arguments are present. **Any** command-line argument will disable the use of the environment variable.
 
-### Triggers
+## Triggers
 The only events/notification triggers that are supported are **On Release Import** and **On Upgrade**
 
-### Batch Mode
-Batch mode allows the script to be executed independently of Lidarr.  It converts the file specified on the command line and ignores any environment variables that are normally expected to be set by the music management program.
+## Batch Mode
+Batch mode allows the script to be executed independently of Lidarr.  It converts the file specified on the command-line and ignores any environment variables that are normally expected to be set by the music management program.
 
 Using this function, you can easily process all of your audio files in any subdirectory at once.  See the [Batch Example](./README.md#batch-example) below.
 
-#### Script Execution Differences in Batch Mode
+### Script Execution Differences in Batch Mode
 Because the script is not called from within Lidarr, expect the following behavior while in Batch Mode:
-* *The filename must be specified on the command line*<br/>(The `-f` option places the script in Batch Mode)
+* *The filename must be specified on the command-line*<br/>(The `-f` option places the script in Batch Mode)
 * *Lidarr APIs are not called and its database is not updated.*<br/>This may require a manual import of converted music files or an artist rescan.
 * *Original audio files are deleted.*<br/>The Recycle Bin function is not available. (Modifiable using the `-k` option.)
 
-#### Batch Example
-To convert all .FLAC files in the `/music` directory to Apple Lossless Audio Codec (ALAC), enter the following at the Linux command line:
+### Batch Example
+To convert all .FLAC files in the `/music` directory to Apple Lossless Audio Codec (ALAC), enter the following at the Linux command-line:
+
 ```shell
 find /music/ -type f -name "*.flac" | while read file; do /usr/local/bin/flac2mp3.sh -f "$file" -a "-c:a alac" -e m4a; done
 ```
 
-### Logs
-By default, a log file is created for the script activity called:
-
-`/config/logs/flac2mp3.txt`
-
-This log can be downloaded from Lidarr under *System* > *Log Files*.  The log filename can be modified with the `--log` command-line option.
-
-Log rotation is performed, with 5 log files of 1MB each kept, matching Lidarr's log retention.
->![danger] **NOTE:** If debug logging is enabled with a level above 1, the log file can grow very large very quickly and is much more likely to be rotated.  *Do not leave high-level debug logging enabled permanently.*
-
-#### Metadata Corrections
-This feature is not meant for general purpose use. It is only documented here for completeness.
+## Metadata Corrections
+**This feature is not meant for general purpose use.** It is only documented here for completeness.
 
 List of supported tags and metadata corrections that are applied:
 
@@ -243,6 +249,16 @@ List of supported tags and metadata corrections that are applied:
 | |/Electronic/|"Electronica & Dance"
 | |/Punk\|Alternative/|"Alternative & Punk"
 | |/Rock/|"Rock"
+
+## Logs
+By default, a log file is created for the script activity called:
+
+`/config/logs/flac2mp3.txt`
+
+This log can be downloaded from Lidarr under *System* > *Log Files*.  The log filename can be modified with the `--log` command-line option.
+
+Log rotation is performed, with 5 log files of 1MB each kept, matching Lidarr's log retention.
+>![danger] **NOTE:** If debug logging is enabled with a level above 1, the log file can grow very large very quickly and is much more likely to be rotated.  *Do not leave high-level debug logging enabled permanently.*
 
 # Uninstall
 To completely remove the mod:

--- a/root/usr/local/bin/flac2mp3-tags.sh
+++ b/root/usr/local/bin/flac2mp3-tags.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-. /usr/local/bin/flac2mp3.sh --tags disc,genre
+. /usr/local/bin/flac2mp3.sh --tags title,disc,genre

--- a/root/usr/local/bin/flac2mp3.sh
+++ b/root/usr/local/bin/flac2mp3.sh
@@ -337,7 +337,7 @@ fi
 function log {(
   while read
   do
-    echo $(date +"%y-%-m-%-d %H:%M:%S.%1N")\|"[$flac2mp3_pid]$REPLY" >>"$flac2mp3_log"
+    echo $(date +"%Y-%m-%d %H:%M:%S.%1N")\|"[$flac2mp3_pid]$REPLY" >>"$flac2mp3_log"
     local flac2mp3_filesize=$(stat -c %s "$flac2mp3_log")
     if [ $flac2mp3_filesize -gt $flac2mp3_maxlogsize ]
     then

--- a/root/usr/local/bin/flac2mp3.sh
+++ b/root/usr/local/bin/flac2mp3.sh
@@ -803,6 +803,7 @@ for flac2mp3_track in $flac2mp3_tracks; do
           ;;
         esac
       done
+      [ $flac2mp3_debug -ge 1 ] && echo "Debug|New metadata: $(echo $flac2mp3_ffmpeg_metadata | sed -e 's/-metadata //g')" | log
     else
       echo "Warn|ffprobe did not return any data when querying track: \"$flac2mp3_track\"" | log
       flac2mp3_exitstatus=12

--- a/root/usr/local/bin/flac2mp3.sh
+++ b/root/usr/local/bin/flac2mp3.sh
@@ -63,6 +63,9 @@ Source: https://github.com/TheCaptain989/lidarr-flac2mp3
 Usage:
   $0 [{-b|--bitrate} <bitrate> | {-v|--quality} <quality> | {-a|--advanced} \"<options>\" {-e|--extension} <extension>] [{-f|--file} <audio_file>] [{-k|--keep-file}] [{-o|--output} <directory>] [{-r|--regex} '<regex>'] [{-t|--tags} <taglist>] [{-l|--log} <log_file>] [{-d|--debug} [<level>]]
 
+  Options can also be set via the FLAC2MP3_ARGS environment variable.
+  Command-line arguments override the environment variable.
+
 Options:
   -b, --bitrate <bitrate>       Set output quality in constant bits per second
                                 [default: 320k]
@@ -321,12 +324,14 @@ if [[ "${flac2mp3_type,,}" = "batch" ]]; then
   # Batch mode
   export lidarr_eventtype="Convert"
 elif [[ "${flac2mp3_type,,}" = "lidarr" ]]; then
+  # shellcheck disable=SC2154
   export flac2mp3_tracks="$lidarr_addedtrackpaths"
   # Catch for other environment variable
+  # shellcheck disable=SC2154
   [ -z "$flac2mp3_tracks" ] && flac2mp3_tracks="$lidarr_trackfile_path"
 else
   # Called in an unexpected way
-  echo -e "Error|Unknown or missing 'lidarr_eventtype' environment variable: ${flac2mp3_type}\nNot called from Lidarr.\nTry using Batch Mode option: -f <file>"
+  echo -e "Error|Unknown or missing '*_eventtype' environment variable: ${flac2mp3_type}\nNot called from Lidarr.\nTry using Batch Mode option: -f <file>"
   exit 7
 fi
 
@@ -335,8 +340,9 @@ fi
 # Can still go over flac2mp3_maxlog if read line is too long
 #  Must include whole function in subshell for read to work!
 function log {(
-  while read
+  while read -r
   do
+    # shellcheck disable=2046
     echo $(date +"%Y-%m-%d %H:%M:%S.%1N")\|"[$flac2mp3_pid]$REPLY" >>"$flac2mp3_log"
     local flac2mp3_filesize=$(stat -c %s "$flac2mp3_log")
     if [ $flac2mp3_filesize -gt $flac2mp3_maxlogsize ]
@@ -352,7 +358,7 @@ function log {(
 # Inspired by https://stackoverflow.com/questions/893585/how-to-parse-xml-in-bash
 function read_xml {
   local IFS=\>
-  read -d \< flac2mp3_xml_entity flac2mp3_xml_content
+  read -r -d \< flac2mp3_xml_entity flac2mp3_xml_content
 }
 # Check Lidarr version
 function get_version {
@@ -426,6 +432,7 @@ function check_job {
 # Get all track files from album
 function get_trackfile_info {
   local url="$flac2mp3_api_url/trackFile"
+  # shellcheck disable=SC2154
   local data="albumId=$lidarr_album_id"
   [ $flac2mp3_debug -ge 1 ] && echo "Debug|Getting track file info for album id $lidarr_album_id. Calling Lidarr API using GET and URL '$url?$data'" | log
   unset flac2mp3_result
@@ -472,6 +479,7 @@ function delete_track {
 # Get file details on possible files to import into Lidarr
 function get_import_info {
   local url="$flac2mp3_api_url/manualimport"
+  # shellcheck disable=SC2154
   local data="artistId=$lidarr_artist_id&folder=$lidarr_artist_path&filterExistingFiles=true&replaceExistingFiles=false"
   [ $flac2mp3_debug -ge 1 ] && echo "Debug|Getting list of files that can be imported. Calling Lidarr API using GET and URL '$url?$data'" | log
   unset flac2mp3_result
@@ -597,8 +605,17 @@ if [ -n "$flac2mp3_prelogmessage" ]; then
   [ $flac2mp3_debug -ge 1 ] && echo "Debug|FLAC2MP3_ARGS: ${FLAC2MP3_ARGS}" | log
 fi
 
-# Log environment
+# Log environment and user
+[ $flac2mp3_debug -ge 2 ] && id | sed 's/^/Debug|Running as: /' | log
 [ $flac2mp3_debug -ge 2 ] && printenv | sort | sed 's/^/Debug|/' | log
+
+# Check for invalid _eventtypes
+if [[ "$lidarr_eventtype" =~ Grab|Rename|TrackRetag|ArtistAdd|ArtistDeleted|AlbumDeleted|ApplicationUpdate|HealthIssue ]]; then
+  flac2mp3_message="Error|Lidarr event ${lidarr_eventtype} is not supported. Exiting."
+  echo "$flac2mp3_message" | log
+  echo "$flac2mp3_message" >&2
+  end_script 20
+fi
 
 # Handle Lidarr Test event
 if [[ "$lidarr_eventtype" = "Test" ]]; then
@@ -692,6 +709,7 @@ fi
 # Build dynamic log message
 flac2mp3_message="Info|Lidarr event: ${lidarr_eventtype}"
 if [ "$flac2mp3_type" != "batch" ]; then
+  # shellcheck disable=SC2154
   flac2mp3_message+=", Artist: ${lidarr_artist_name} (${lidarr_artist_id}), Album: ${lidarr_album_title} (${lidarr_album_id})"
 fi
 if [ -z "$flac2mp3_ffmpegadv" ]; then
@@ -769,6 +787,7 @@ for flac2mp3_track in $flac2mp3_tracks; do
     # Get track metadata
     if ffprobe "$flac2mp3_track"; then
       for flac2mp3_tag in $(echo $flac2mp3_tags | tr ',' '|'); do
+        # shellcheck disable=SC2089
         case "$flac2mp3_tag" in
           title )  # Fix for parenthesis in titles for live and mix names
             flac2mp3_tag_title=$(echo "$flac2mp3_ffprobe_json" | jq -crM '.format.tags | to_entries[] | select(.key | match("title"; "i")).value')
@@ -803,7 +822,8 @@ for flac2mp3_track in $flac2mp3_tracks; do
           ;;
         esac
       done
-      [ $flac2mp3_debug -ge 1 ] && echo "Debug|New metadata: $(echo $flac2mp3_ffmpeg_metadata | sed -e 's/-metadata //g')" | log
+      # shellcheck disable=SC2090
+      [ $flac2mp3_debug -ge 1 ] && echo "Debug|New metadata: echo ${flac2mp3_ffmpeg_metadata//-metadata /}" | log
     else
       echo "Warn|ffprobe did not return any data when querying track: \"$flac2mp3_track\"" | log
       flac2mp3_exitstatus=12
@@ -831,12 +851,25 @@ for flac2mp3_track in $flac2mp3_tracks; do
     continue
   fi
 
-  # Set owner and permissions
-  [ $flac2mp3_debug -ge 1 ] && echo "Debug|Changing ownership and permissions of \"$flac2mp3_newTrack\"" | log
-  chown --reference="$flac2mp3_track" "$flac2mp3_newTrack" >&2
+  # Checking that we're running as root
+  if [ "$(id -u)" -eq 0 ]; then
+    # Set owner
+    [ $flac2mp3_debug -ge 1 ] && echo "Debug|Changing owner of file \"$flac2mp3_newTrack\"" | log
+    chown --reference="$flac2mp3_track" "$flac2mp3_newTrack" >&2
+    flac2mp3_return=$?; [ $flac2mp3_return -ne 0 ] && {
+      flac2mp3_message="Error|[$flac2mp3_return] Error when changing owner of track: \"$flac2mp3_newTrack\""
+      echo "$flac2mp3_message" | log
+      echo "$flac2mp3_message" >&2
+      flac2mp3_exitstatus=15
+    }
+  else
+    # Unable to change owner when not running as root
+    [ $flac2mp3_debug -ge 1 ] && echo "Debug|Unable to change owner of track when running as user '$(id -un)'" | log
+  fi
+  # Set permissions
   chmod --reference="$flac2mp3_track" "$flac2mp3_newTrack" >&2
   flac2mp3_return=$?; [ $flac2mp3_return -ne 0 ] && {
-    flac2mp3_message="Error|[$flac2mp3_return] Error when changing ownership or permissions of track: \"$flac2mp3_newTrack\""
+    flac2mp3_message="Error|[$flac2mp3_return] Error when changing permissions of track: \"$flac2mp3_newTrack\""
     echo "$flac2mp3_message" | log
     echo "$flac2mp3_message" >&2
     flac2mp3_exitstatus=15


### PR DESCRIPTION
## What's Changed
- **New:** Added check for invalid eventtypes
- **New:** Owner change is only executed as root
- Additional debug output for tag handling
- Added id debug output
- Added title tag to flac2mp3-tags.sh file
- Updated datetime format in log files to match Lidarr
- Fully linted code
- Updated build stage to Alpine 3.19
