### PR TITLE
Set FFMPEG_PATH for Jellyfin 10.8.13+ support. Update Readme

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-rffmpeg-setup/run
@@ -41,3 +41,8 @@ else
         s6-setuidgid abc /usr/local/bin/rffmpeg add --weight 1 $RFFMPEG_HOST
     fi
 fi
+
+#Set ffmpeg path if not set by user
+if [ -z "$FFMPEG_PATH" ]; then
+    printf "/usr/local/bin/wol_rffmpeg/ffmpeg" > /var/run/s6/container_environment/FFMPEG_PATH
+fi


### PR DESCRIPTION
This request supersedes #900 and resolves #899. It sets FFMPEG_PATH to use the WOL compatible wrapper script for rffmpeg already in this mod to bring mod back into compatibility with Jellyfin 10.8.13 and 10.9 due to breaking change to allow user to set ffmpeg to a custom path using the webgui. Readme file updated to reflect this change and simplify slightly.