### PR TITLE
Maxmind: Add new required var for userid

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Follow these steps to enable the maxmind mod:
 2. In the container's docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:swag-maxmind`
    
    If adding multiple mods, enter them in an array separated by `|`, such as `DOCKER_MODS=linuxserver/mods:swag-maxmind|linuxserver/mods:swag-mod2`
-3. In the container's docker arguments, set an environment variable `MAXMINDDB_LICENSE_KEY=<license-key>` with your license key.
+3. In the container's docker arguments, set the following environment variables:
+    - `MAXMINDDB_LICENSE_KEY=<license-key>` with your license key
+    - `MAXMINDDB_USER_ID=<user-id>` with your user id
 4. Recreate the container to apply the changes.
 5. Add the following line to `/config/nginx/nginx.conf` under the `http` section:
    

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-maxmind-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-maxmind-setup/run
@@ -12,7 +12,12 @@ if [[ ! -d /var/lib/libmaxminddb ]]; then
     ln -s /config/geoip2db /var/lib/libmaxminddb
 fi
 # check GeoIP2 database
-if [[ -n "$MAXMINDDB_LICENSE_KEY" ]]; then
+if [[ -n "${MAXMINDDB_USER_ID}" ]]; then
+    sed -i "s|.*MAXMINDDB_USER_ID.*|MAXMINDDB_USER_ID=\"${MAXMINDDB_USER_ID}\"|g" /etc/libmaxminddb.cron.conf
+else
+    echo "Starting with Alpine 3.20 rebase, MaxMindDB now requires setting the env var MAXMINDDB_USER_ID with your account's user id."
+fi
+if [[ -n "${MAXMINDDB_LICENSE_KEY}" ]]; then
     sed -i "s|.*MAXMINDDB_LICENSE_KEY.*|MAXMINDDB_LICENSE_KEY=\"${MAXMINDDB_LICENSE_KEY}\"|g" /etc/libmaxminddb.cron.conf
     if [[ ! -f /var/lib/libmaxminddb/GeoLite2-City.mmdb ]]; then
         echo "Downloading GeoIP2 City database."


### PR DESCRIPTION
Alpine 3.20 libmaxmind package requires the user id set as well

On earlier versions, this PR should only print a warning, but not actually break anything.