### PR TITLE
Add support for multiple docker hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ DOCKER_HOST=192.168.0.100:2375|serverA,192.168.0.110:2375|serverB|local.test,192
 
 ### Upstream IP and Port
 
-When using a remote docker host from `DOCKER_HOST` auto-proxy assumes the detected containers on not on the same network as SWAG:
+When using a remote docker host from `DOCKER_HOST` auto-proxy assumes the detected containers are not on the same network as SWAG:
 
 * If the detected containers do not have the `swag_address` label set then the Host IP will be used.
 * If the detected containers do not have the `swag_port` label set then auto-proxy attempts to find a mapped **host port** on the container and will use it based on **container port** in this order:
@@ -68,11 +68,11 @@ When using a remote docker host from `DOCKER_HOST` auto-proxy assumes the detect
 
 ### Subdomains and TLD
 
-If a detected container does not have `swag_url` label set then the subdomain and TLD can be programmatically generated.
+If a detected container does not have the `swag_url` label set then the subdomain and TLD can be programmatically generated.
 
 The default TLD used in nginx [`server_name` directive](https://nginx.org/en/docs/http/server_names.html) can be set using `HOST_TLD`. This can also be set per-host using the syntax described in [`DOCKER_HOST` for `default_tld`.](#multiple-hosts)
 
-The subdomain used for a container can optionally be modified to include the Host's `friendly_name` described in the `DOCKER_HOST` syntax by setting the `HOST_INSERT` to either `prefix` or `suffix`
+The subdomain used for a container can optionally be modified to include the Host's `friendly_name` described in the `DOCKER_HOST` syntax by setting `HOST_INSERT` to either `prefix` or `suffix`
 
 Examples using a container named `overseer`:
 
@@ -80,7 +80,7 @@ Examples using a container named `overseer`:
   * `DOCKER_HOST=192.168.0.100:2375|serverA`
   * `HOST_TLD` (not set, defaults to `*`)
   * `HOST_INSERT`
-    * (unset) => nginx `server_name swag.*`
+    * (unset) => nginx `server_name overseer.*`
     * `prefix` => nginx `server_name serverA-overseer.*`
     * `suffix` => nginx `server_name overseer-serverA.*`
 * Using HOST_INSERT prefix and HOST_TLD

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ DOCKER_HOST=192.168.0.100:2375|serverA,192.168.0.110:2375|serverB|local.test,192
 When using a remote docker host from `DOCKER_HOST` auto-proxy assumes the detected containers are not on the same network as SWAG:
 
 * If the detected containers do not have the `swag_address` label set then the Host IP will be used.
-* If the detected containers do not have the `swag_port` label set then auto-proxy attempts to find a mapped **host port** on the container and will use it based on **container port** in this order:
+* If the detected containers do not have the `swag_port` label set then auto-proxy looks for exposed **container ports** and uses the corresponding **host port** as the upstream port. Container ports are checked in this order:
   * 80
   * 8080
   * The first mapped port, if any
@@ -70,29 +70,29 @@ When using a remote docker host from `DOCKER_HOST` auto-proxy assumes the detect
 
 If a detected container does not have the `swag_url` label set then the subdomain and TLD can be programmatically generated.
 
-The default TLD used in nginx [`server_name` directive](https://nginx.org/en/docs/http/server_names.html) can be set using `HOST_TLD`. This can also be set per-host using the syntax described in [`DOCKER_HOST` for `default_tld`.](#multiple-hosts)
+The default TLD used in nginx [`server_name` directive](https://nginx.org/en/docs/http/server_names.html) can be set using `AUTO_PROXY_HOST_TLD`. This can also be set per-host using the syntax described in [`DOCKER_HOST` for `default_tld`.](#multiple-hosts)
 
-The subdomain used for a container can optionally be modified to include the Host's `friendly_name` described in the `DOCKER_HOST` syntax by setting `HOST_INSERT` to either `prefix` or `suffix`
+The subdomain used for a container can optionally be modified to include the Host's `friendly_name` described in the `DOCKER_HOST` syntax by setting `AUTO_PROXY_HOST_INSERT` to either `prefix` or `suffix`
 
 Examples using a container named `overseer`:
 
-* Using only HOST_INSERT to modify subdomain
+* Using only AUTO_PROXY_HOST_INSERT to modify subdomain
   * `DOCKER_HOST=192.168.0.100:2375|serverA`
-  * `HOST_TLD` (not set, defaults to `*`)
-  * `HOST_INSERT`
+  * `AUTO_PROXY_HOST_TLD` (not set, defaults to `*`)
+  * `AUTO_PROXY_HOST_INSERT`
     * (unset) => nginx `server_name overseer.*`
     * `prefix` => nginx `server_name serverA-overseer.*`
     * `suffix` => nginx `server_name overseer-serverA.*`
-* Using HOST_INSERT prefix and HOST_TLD
+* Using AUTO_PROXY_HOST_INSERT prefix and AUTO_PROXY_HOST_TLD
   * `DOCKER_HOST=192.168.0.100:2375|serverA`
-  * `HOST_TLD=test.home`
-  * `HOST_INSERT=prefix`
+  * `AUTO_PROXY_HOST_TLD=test.home`
+  * `AUTO_PROXY_HOST_INSERT=prefix`
     * `server_name serverA-overseer.test.home`
-* Using HOST_INSERT prefix and default_tld
+* Using AUTO_PROXY_HOST_INSERT prefix and default_tld
   * `DOCKER_HOST=192.168.0.100:2375|serverA|myserver.home`
-  * `HOST_INSERT=prefix`
+  * `AUTO_PROXY_HOST_INSERT=prefix`
     * `server_name serverA-overseer.myserver.home`
-* Using HOST_TLD only
+* Using AUTO_PROXY_HOST_TLD only
   * `DOCKER_HOST=192.168.0.100:2375`
-  * `HOST_TLD=myserver.home`
+  * `AUTO_PROXY_HOST_TLD=myserver.home`
     * `server_name overseer.myserver.home`

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Then the env var in SWAG can be set as `DOCKER_HOST=dockerproxy`. This will allo
 
 ## Multiple Hosts:
 
+In the `DOCKER_MODS` env mentioned above replace `linuxserver/mods:swag-auto-proxy` with `foxxmd/auto-proxy-multi`.
+
 If both `DOCKER_HOST` and `docker.sock` volumes are provided this mod will detect containers using both connections. As noted in the [requirements](#requirements), containers detected via `docker.sock` must be in the same user defined network or have `swag_address` label set.
 
 Multiple remote hosts can be used via `DOCKER_HOST` by separating hosts with a comma. Additional per-host settings can be assigned by separating with a pipe `|`. The syntax for per-host configuration:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Auto-proxy - Docker mod for SWAG
 
-This mod gives SWAG the ability to auto-detect running containers via labels and automatically enable reverse proxy for them.
+This mod gives SWAG the ability to auto-detect running containers, across multiple hosts, via labels and automatically enable reverse proxy for them.
 
 ## Requirements:
 - This mod needs the [universal-docker mod](https://github.com/linuxserver/docker-mods/tree/universal-docker) installed and set up with either mapping `docker.sock` or setting the environment variable `DOCKER_HOST=remoteaddress`.
-- Other containers to be auto-detected and reverse proxied should be in the same [user defined bridge network](https://docs.linuxserver.io/general/swag#docker-networking) as SWAG.
+- Other containers detected via `docker.sock` to be auto-detected and reverse proxied should be in the same [user defined bridge network](https://docs.linuxserver.io/general/swag#docker-networking) as SWAG.
 - Containers to be auto-detected and reverse proxied must have a label `swag=enable` at a minimum.
 - To benefit from curated preset proxy confs we provide, the container name must match the container names that are suggested in our readme examples (ie. `radarr` and not `Radarr-4K`).
 
@@ -36,3 +36,28 @@ Here's a sample compose yaml snippet for tecnativa/docker-socket-proxy:
       - POST=0
 ```
 Then the env var in SWAG can be set as `DOCKER_HOST=dockerproxy`. This will allow docker cli in SWAG to be able to retrieve info on other containers, but it won't be allowed to spin up new containers.
+
+## Multiple Hosts:
+
+If both `DOCKER_HOST` and `docker.sock` volumes are provided this mod will detect containers using both connections. As noted in the [requirements](#requirements), containers detected via `docker.sock` must be in the same user defined network or have `swag_address` label set.
+
+Multiple remote hosts can be used via `DOCKER_HOST` by separating hosts with a comma. Additionally, a friendly host name can be assigned by suffixing the host with `|friendlyName`. If the host is not assigned a friendly name it will have a default generated like `hostN` where N is the position of the host in `DOCKER_HOST`. Example:
+
+```
+DOCKER_HOST=192.168.0.100:2375|serverA,192.168.0.110:2375|serverB,192.168.0.130:2375
+```
+
+* Host: `192.168.0.100:2375` -- Friendly Name: `serverA`
+* Host: `192.168.0.110:2375` -- Friendly Name: `serverB`
+* Host: `192.168.0.130:2375` -- Friendly Name: `host3`
+
+If the detected containers for each host do not have the `swag_address` label set then the host IP will be used.
+
+If the detected containers for each host do not have the `swag_url` label set then the default can be configured with friendly host name inserted into the url as either a suffix or prefix using the env `HOST_INSERT`. Example:
+
+* container name: `swag`
+* `DOCKER_HOST=192.168.0.100:2375|serverA`
+* `HOST_INSERT`
+  * (unset) => nginx `server_name swag.*`
+  * `prefix` => nginx `server_name serverA-swag.*`
+  * `suffix` => nginx `server_name swag-serverA.*`

--- a/root/app/auto-proxy.sh
+++ b/root/app/auto-proxy.sh
@@ -138,7 +138,6 @@ DUDE
               else
                 echo "**** No exposed ports found for ${CONTAINER_ID}. Setting reverse proxy port to 80. ****"
                 swag_port="80"
-               swag_address="${UPSTREAM_HOST}"
               fi
             else
               swag_port=$(docker inspect ${CONTAINER} | jq -r '.[0].NetworkSettings.Ports | keys[0]' | sed 's|/.*||')
@@ -156,12 +155,12 @@ DUDE
         sed -i "s|set \$upstream_proto .*|set \$upstream_proto ${swag_proto};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
         echo "**** Setting proto ${swag_proto} for ${CONTAINER_ID} ****"
         if [ -z "${swag_url}" ]; then
-            if [ "$HOST_INSERT" == "suffix" ]; then
-              swag_url="${CONTAINER}-${DOCKER_HOST_NAME}.${HOST_TLD}"
-            elif [ "$HOST_INSERT" == "prefix" ]; then
-              swag_url="${DOCKER_HOST_NAME}-${CONTAINER}.${HOST_TLD}"
+            if [ "$AUTO_PROXY_HOST_INSERT" == "suffix" ]; then
+              swag_url="${CONTAINER}-${DOCKER_HOST_NAME}.${AUTO_PROXY_HOST_TLD}"
+            elif [ "$AUTO_PROXY_HOST_INSERT" == "prefix" ]; then
+              swag_url="${DOCKER_HOST_NAME}-${CONTAINER}.${AUTO_PROXY_HOST_TLD}"
             else
-              swag_url="${CONTAINER}.${HOST_TLD}"
+              swag_url="${CONTAINER}.${AUTO_PROXY_HOST_TLD}"
             fi
         fi
         sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"

--- a/root/app/auto-proxy.sh
+++ b/root/app/auto-proxy.sh
@@ -157,11 +157,11 @@ DUDE
         echo "**** Setting proto ${swag_proto} for ${CONTAINER_ID} ****"
         if [ -z "${swag_url}" ]; then
             if [ "$HOST_INSERT" == "suffix" ]; then
-              swag_url="${CONTAINER}-${DOCKER_HOST_NAME}.*"
+              swag_url="${CONTAINER}-${DOCKER_HOST_NAME}.${HOST_TLD}"
             elif [ "$HOST_INSERT" == "prefix" ]; then
-              swag_url="${DOCKER_HOST_NAME}-${CONTAINER}.*"
+              swag_url="${DOCKER_HOST_NAME}-${CONTAINER}.${HOST_TLD}"
             else
-              swag_url="${CONTAINER}.*"
+              swag_url="${CONTAINER}.${HOST_TLD}"
             fi
         fi
         sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"

--- a/root/app/auto-proxy.sh
+++ b/root/app/auto-proxy.sh
@@ -2,14 +2,15 @@
 
 AUTO_GEN=""
 # figure out which containers to generate confs for or which confs to remove
-if [ ! -f /auto-proxy/enabled_containers ]; then
-    docker ps --filter "label=swag=enable" --format "{{.Names}}" > /auto-proxy/enabled_containers
-    AUTO_GEN=$(cat /auto-proxy/enabled_containers)
+if [ ! -f /auto-proxy/enabled_containers_"$DOCKER_HOST_NAME" ]; then
+    docker ps --filter "label=swag=enable" --format "{{.Names}}" > /auto-proxy/enabled_containers_"$DOCKER_HOST_NAME"
+    AUTO_GEN=$(cat /auto-proxy/enabled_containers_"$DOCKER_HOST_NAME")
 else
     ENABLED_CONTAINERS=$(docker ps --filter "label=swag=enable" --format "{{.Names}}")
     for CONTAINER in ${ENABLED_CONTAINERS}; do
-        if [ ! -f "/auto-proxy/${CONTAINER}.conf" ]; then
-            echo "**** New container ${CONTAINER} detected, will generate new conf. ****"
+        CONTAINER_ID="${DOCKER_HOST_NAME}-${CONTAINER}"
+        if [ ! -f "/auto-proxy/${CONTAINER_ID}.conf" ]; then
+            echo "**** New container ${CONTAINER_ID} detected, will generate new conf. ****"
             AUTO_GEN="${CONTAINER} ${AUTO_GEN}"
         else
             INSPECTION=$(docker inspect ${CONTAINER})
@@ -18,84 +19,86 @@ else
                 if [ "${VAR_VALUE}" == "null" ]; then
                     VAR_VALUE=""
                 fi
-                if ! grep -F -q "${VAR}=\"${VAR_VALUE}\"" "/auto-proxy/${CONTAINER}.conf"; then
+                if ! grep -F -q "${VAR}=\"${VAR_VALUE}\"" "/auto-proxy/${CONTAINER_ID}.conf"; then
                     AUTO_GEN="${CONTAINER} ${AUTO_GEN}"
-                    echo "**** Labels for ${CONTAINER} changed, will generate new conf. ****"
+                    echo "**** Labels for ${CONTAINER_ID} changed, will generate new conf. ****"
                     break
                 fi
             done
         fi
     done
-    EXISTING_CONFS=$(cat /auto-proxy/enabled_containers)
+    EXISTING_CONFS=$(cat /auto-proxy/enabled_containers_"$DOCKER_HOST_NAME")
     for CONTAINER in $EXISTING_CONFS; do
+        CONTAINER_ID="${DOCKER_HOST_NAME}-${CONTAINER}"
         if ! grep -q "${CONTAINER}" <<< "${ENABLED_CONTAINERS}"; then
-            echo "**** Removing conf for ${CONTAINER} ****"
-            rm -rf "/auto-proxy/${CONTAINER}.conf" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            echo "**** Removing conf for ${CONTAINER_ID} ****"
+            rm -rf "/auto-proxy/${CONTAINER_ID}.conf" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
             REMOVED_CONTAINERS="true"
         fi
     done
-    echo "${ENABLED_CONTAINERS}" > /auto-proxy/enabled_containers
+    echo "${ENABLED_CONTAINERS}" > /auto-proxy/enabled_containers_"$DOCKER_HOST_NAME"
 fi
 
 for CONTAINER in ${AUTO_GEN}; do
+    CONTAINER_ID="${DOCKER_HOST_NAME}-${CONTAINER}"
     INSPECTION=$(docker inspect ${CONTAINER})
-    rm -rf "/auto-proxy/${CONTAINER}.conf"
+    rm -rf "/auto-proxy/${CONTAINER_ID}.conf"
     for VAR in swag_address swag_port swag_proto swag_url swag_auth swag_auth_bypass; do
         VAR_VALUE=$(echo ${INSPECTION} | jq -r ".[0].Config.Labels[\"${VAR}\"]")
         if [ "${VAR_VALUE}" == "null" ]; then
             VAR_VALUE=""
         fi
-        echo "${VAR}=\"${VAR_VALUE}\"" >> "/auto-proxy/${CONTAINER}.conf"
+        echo "${VAR}=\"${VAR_VALUE}\"" >> "/auto-proxy/${CONTAINER_ID}.conf"
     done
-    . /auto-proxy/${CONTAINER}.conf
-    if [ -f "/config/nginx/proxy-confs/${CONTAINER}.subdomain.conf.sample" ]; then
-        cp "/config/nginx/proxy-confs/${CONTAINER}.subdomain.conf.sample" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-        echo "**** Using preset proxy conf for ${CONTAINER} ****"
+    . /auto-proxy/"${CONTAINER_ID}".conf
+    if [ -f "/config/nginx/proxy-confs/${CONTAINER_ID}.subdomain.conf.sample" ]; then
+        cp "/config/nginx/proxy-confs/${CONTAINER_ID}.subdomain.conf.sample" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+        echo "**** Using preset proxy conf for ${CONTAINER_ID} ****"
         if [ -n "${swag_auth_bypass}" ]; then
             echo "**** Swag auth bypass is auto managed via preset confs and cannot be overridden via env vars ****"
         fi
         if [ -n "${swag_address}" ]; then
-            sed -i "s|set \$upstream_app .*|set \$upstream_app ${swag_address};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Overriding address as ${swag_address} for ${CONTAINER} ****"
+            sed -i "s|set \$upstream_app .*|set \$upstream_app ${swag_address};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Overriding address as ${swag_address} for ${CONTAINER_ID} ****"
         fi
         if [ -n "${swag_port}" ]; then
-            sed -i "s|set \$upstream_port .*|set \$upstream_port ${swag_port};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Overriding port as ${swag_port} for ${CONTAINER} ****"
+            sed -i "s|set \$upstream_port .*|set \$upstream_port ${swag_port};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Overriding port as ${swag_port} for ${CONTAINER_ID} ****"
         fi
         if [ -n "${swag_proto}" ]; then
-            sed -i "s|set \$upstream_proto .*|set \$upstream_proto ${swag_proto};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Overriding proto as ${swag_proto} for ${CONTAINER} ****"
+            sed -i "s|set \$upstream_proto .*|set \$upstream_proto ${swag_proto};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Overriding proto as ${swag_proto} for ${CONTAINER_ID} ****"
         fi
         if [ -n "${swag_url}" ]; then
-            sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Overriding url as ${swag_url} for ${CONTAINER} ****"
+            sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Overriding url as ${swag_url} for ${CONTAINER_ID} ****"
         fi
         if [ "${swag_auth}" == "authelia" ]; then
-            sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling Authelia for ${CONTAINER} ****"
+            sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling Authelia for ${CONTAINER_ID} ****"
         elif [ "${swag_auth}" == "authentik" ]; then
-            sed -i "s|#include /config/nginx/authentik|include /config/nginx/authentik|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling Authentik for ${CONTAINER} ****"
+            sed -i "s|#include /config/nginx/authentik|include /config/nginx/authentik|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling Authentik for ${CONTAINER_ID} ****"
         elif [ "${swag_auth}" == "http" ]; then
-            sed -i "s|#auth_basic|auth_basic|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling basic http auth for ${CONTAINER} ****"
+            sed -i "s|#auth_basic|auth_basic|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling basic http auth for ${CONTAINER_ID} ****"
         elif [ "${swag_auth}" == "ldap" ]; then
             # Old (before standard-base)
-            sed -i "s|#include /config/nginx/ldap.conf;|include /config/nginx/ldap.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            sed -i "s|#auth_request /auth;|auth_request /auth;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            sed -i "s|#error_page 401 =200 /ldaplogin;|error_page 401 =200 /ldaplogin;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            sed -i "s|#include /config/nginx/ldap.conf;|include /config/nginx/ldap.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            sed -i "s|#auth_request /auth;|auth_request /auth;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            sed -i "s|#error_page 401 =200 /ldaplogin;|error_page 401 =200 /ldaplogin;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
             # New (after standard-base)
-            sed -i "s|#include /config/nginx/ldap-server.conf;|include /config/nginx/ldap-server.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            sed -i "s|#include /config/nginx/ldap-location.conf;|include /config/nginx/ldap-location.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling basic http auth for ${CONTAINER} ****"
+            sed -i "s|#include /config/nginx/ldap-server.conf;|include /config/nginx/ldap-server.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            sed -i "s|#include /config/nginx/ldap-location.conf;|include /config/nginx/ldap-location.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling basic http auth for ${CONTAINER_ID} ****"
         fi
     else
-        echo "**** No preset proxy conf found for ${CONTAINER}, generating from scratch ****"
-        cp "/config/nginx/proxy-confs/_template.subdomain.conf.sample" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+        echo "**** No preset proxy conf found for ${CONTAINER_ID}, generating from scratch ****"
+        cp "/config/nginx/proxy-confs/_template.subdomain.conf.sample" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
         if [ -n "${swag_auth_bypass}" ]; then
-            sed -i 's|^}$||' "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            sed -i 's|^}$||' "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
             for location in $(echo ${swag_auth_bypass} | tr "," " "); do
-                cat <<DUDE >> "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+                cat <<DUDE >> "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
 
     location ~ ${location} {
         include /config/nginx/proxy.conf;
@@ -109,50 +112,60 @@ for CONTAINER in ${AUTO_GEN}; do
 
 DUDE
             done
-            echo "}" >> "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            echo "}" >> "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
         fi
         if [ -z "${swag_address}" ]; then
-            swag_address="${CONTAINER}"
+              if [[ -v UPSTREAM_HOST ]];then
+                swag_address="${UPSTREAM_HOST}"
+              else
+                swag_address="${CONTAINER}"
+              fi
         fi
-        sed -i "s|<container_name>|${swag_address}|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-        echo "**** Setting upstream address ${swag_address} for ${CONTAINER} ****"
+        sed -i "s|<container_name>|${swag_address}|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+        echo "**** Setting upstream address ${swag_address} for ${CONTAINER_ID} ****"
         if [ -z "${swag_port}" ]; then
             swag_port=$(docker inspect ${CONTAINER} | jq -r '.[0].NetworkSettings.Ports | keys[0]' | sed 's|/.*||')
             if [ "${swag_port}" == "null" ]; then
-                echo "**** No exposed ports found for ${CONTAINER}. Setting reverse proxy port to 80. ****"
+                echo "**** No exposed ports found for ${CONTAINER_ID}. Setting reverse proxy port to 80. ****"
                 swag_port="80"
             fi
         fi
-        sed -i "s|set \$upstream_port .*|set \$upstream_port ${swag_port};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-        echo "**** Setting port ${swag_port} for ${CONTAINER} ****"
+        sed -i "s|set \$upstream_port .*|set \$upstream_port ${swag_port};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+        echo "**** Setting port ${swag_port} for ${CONTAINER_ID} ****"
         if [ -z "${swag_proto}" ]; then
             swag_proto="http"
         fi
-        sed -i "s|set \$upstream_proto .*|set \$upstream_proto ${swag_proto};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-        echo "**** Setting proto ${swag_proto} for ${CONTAINER} ****"
+        sed -i "s|set \$upstream_proto .*|set \$upstream_proto ${swag_proto};|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+        echo "**** Setting proto ${swag_proto} for ${CONTAINER_ID} ****"
         if [ -z "${swag_url}" ]; then
-            swag_url="${CONTAINER}.*"
+            if [ "$HOST_INSERT" == "suffix" ]; then
+              swag_url="${CONTAINER}-${DOCKER_HOST_NAME}.*"
+            elif [ "$HOST_INSERT" == "prefix" ]; then
+              swag_url="${DOCKER_HOST_NAME}-${CONTAINER}.*"
+            else
+              swag_url="${CONTAINER}.*"
+            fi
         fi
-        sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-        echo "**** Setting url ${swag_url} for ${CONTAINER} ****"
+        sed -i "s|server_name .*|server_name ${swag_url};|" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+        echo "**** Setting url ${swag_url} for ${CONTAINER_ID} ****"
         if [ "${swag_auth}" == "authelia" ]; then
-            sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling Authelia for ${CONTAINER} ****"
+            sed -i "s|#include /config/nginx/authelia|include /config/nginx/authelia|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling Authelia for ${CONTAINER_ID} ****"
         elif [ "${swag_auth}" == "authentik" ]; then
-            sed -i "s|#include /config/nginx/authentik|include /config/nginx/authentik|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling Authentik for ${CONTAINER} ****"
+            sed -i "s|#include /config/nginx/authentik|include /config/nginx/authentik|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling Authentik for ${CONTAINER_ID} ****"
         elif [ "${swag_auth}" == "http" ]; then
-            sed -i "s|#auth_basic|auth_basic|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling basic http auth for ${CONTAINER} ****"
+            sed -i "s|#auth_basic|auth_basic|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling basic http auth for ${CONTAINER_ID} ****"
         elif [ "${swag_auth}" == "ldap" ]; then
             # Old (before standard-base)
-            sed -i "s|#include /config/nginx/ldap.conf;|include /config/nginx/ldap.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            sed -i "s|#auth_request /auth;|auth_request /auth;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            sed -i "s|#error_page 401 =200 /ldaplogin;|error_page 401 =200 /ldaplogin;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
+            sed -i "s|#include /config/nginx/ldap.conf;|include /config/nginx/ldap.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            sed -i "s|#auth_request /auth;|auth_request /auth;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            sed -i "s|#error_page 401 =200 /ldaplogin;|error_page 401 =200 /ldaplogin;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
             # New (after standard-base)
-            sed -i "s|#include /config/nginx/ldap-server.conf;|include /config/nginx/ldap-server.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            sed -i "s|#include /config/nginx/ldap-location.conf;|include /config/nginx/ldap-location.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER}.subdomain.conf"
-            echo "**** Enabling basic http auth for ${CONTAINER} ****"
+            sed -i "s|#include /config/nginx/ldap-server.conf;|include /config/nginx/ldap-server.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            sed -i "s|#include /config/nginx/ldap-location.conf;|include /config/nginx/ldap-location.conf;|g" "/etc/nginx/http.d/auto-proxy-${CONTAINER_ID}.subdomain.conf"
+            echo "**** Enabling basic http auth for ${CONTAINER_ID} ****"
         fi
     fi
 done

--- a/root/app/docker-wrap.sh
+++ b/root/app/docker-wrap.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/with-contenv bash
+
+if [[ -v FIRST_RUN ]];then
+  echo '**** Auto Proxy - first-run ****'
+fi
+if [[ -v DOCKER_HOST ]];then
+  if [[ -v FIRST_RUN ]];then
+    echo '**** Auto Proxy - Detected DOCKER_HOST usage ****'
+  fi
+  INDEX=1
+  IFS=',' read -ra DOCKER_DATA <<< "$DOCKER_HOST"
+  for i in "${DOCKER_DATA[@]}"; do
+    arrIN=(${i//|/ })
+    DOCKER_HOST=${arrIN[0]}
+    if [[ -v arrIN[1] ]];then
+      DOCKER_HOST_NAME=${arrIN[1]}
+    else
+      DOCKER_HOST_NAME="host${INDEX}"
+    fi
+
+    # get default upstream ip
+    HOST_PARTS=(${DOCKER_HOST//:/ })
+    UPSTREAM_HOST="${HOST_PARTS[0]}"
+
+    if [[ -v FIRST_RUN ]];then
+      echo "**** Auto Proxy - Generating proxies for => Host: ${DOCKER_HOST} | Name: ${DOCKER_HOST_NAME:-N/A} | Default Upstream IP: ${UPSTREAM_HOST} ****"
+    fi
+    . /app/auto-proxy.sh
+
+    let INDEX=${INDEX}+1
+  done
+fi
+
+if [ -S /var/run/docker.sock ]; then
+  if [[ -v FIRST_RUN ]];then
+    echo '**** Auto Proxy - Detected docker.sock, generating proxies for => Host: Local | Name: Local | Default Upstream IP: N/A ****'
+  fi
+  DOCKER_HOST_NAME="local"
+  unset DOCKER_HOST
+  unset UPSTREAM_HOST
+  . /app/auto-proxy.sh
+fi
+if [[ -v FIRST_RUN ]];then
+  echo '**** Auto Proxy - first-run finished ****'
+fi

--- a/root/app/docker-wrap.sh
+++ b/root/app/docker-wrap.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/with-contenv bash
 
+HOST_TLD_ORIG=${HOST_TLD:=*}
 if [[ -v FIRST_RUN ]];then
   echo '**** Auto Proxy - first-run ****'
 fi
@@ -18,12 +19,18 @@ if [[ -v DOCKER_HOST ]];then
       DOCKER_HOST_NAME="host${INDEX}"
     fi
 
+    if [[ -v arrIN[2] ]];then
+      HOST_TLD=${arrIN[2]}
+    else
+      HOST_TLD=$HOST_TLD_ORIG
+    fi
+
     # get default upstream ip
     HOST_PARTS=(${DOCKER_HOST//:/ })
     UPSTREAM_HOST="${HOST_PARTS[0]}"
 
     if [[ -v FIRST_RUN ]];then
-      echo "**** Auto Proxy - Generating proxies for => Host: ${DOCKER_HOST} | Name: ${DOCKER_HOST_NAME:-N/A} | Default Upstream IP: ${UPSTREAM_HOST} ****"
+      echo "**** Auto Proxy - Generating proxies for => Host: ${DOCKER_HOST} | Name: ${DOCKER_HOST_NAME:-N/A} | Default Upstream IP: ${UPSTREAM_HOST} | Host TLD: ${HOST_TLD} ****"
     fi
     . /app/auto-proxy.sh
 
@@ -33,7 +40,7 @@ fi
 
 if [ -S /var/run/docker.sock ]; then
   if [[ -v FIRST_RUN ]];then
-    echo '**** Auto Proxy - Detected docker.sock, generating proxies for => Host: Local | Name: Local | Default Upstream IP: N/A ****'
+    echo "**** Auto Proxy - Detected docker.sock, generating proxies for => Host: Local | Name: Local | Default Upstream IP: N/A | Host TLD: ${HOST_TLD} ****"
   fi
   DOCKER_HOST_NAME="local"
   unset DOCKER_HOST

--- a/root/app/docker-wrap.sh
+++ b/root/app/docker-wrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-HOST_TLD_ORIG=${HOST_TLD:=*}
+HOST_TLD_ORIG=${AUTO_PROXY_HOST_TLD:=*}
 if [[ -v FIRST_RUN ]];then
   echo '**** Auto Proxy - first-run ****'
 fi
@@ -20,9 +20,9 @@ if [[ -v DOCKER_HOST ]];then
     fi
 
     if [[ -v arrIN[2] ]];then
-      HOST_TLD=${arrIN[2]}
+      AUTO_PROXY_HOST_TLD=${arrIN[2]}
     else
-      HOST_TLD=$HOST_TLD_ORIG
+      AUTO_PROXY_HOST_TLD=$HOST_TLD_ORIG
     fi
 
     # get default upstream ip
@@ -30,7 +30,7 @@ if [[ -v DOCKER_HOST ]];then
     UPSTREAM_HOST="${HOST_PARTS[0]}"
 
     if [[ -v FIRST_RUN ]];then
-      echo "**** Auto Proxy - Generating proxies for => Host: ${DOCKER_HOST} | Name: ${DOCKER_HOST_NAME:-N/A} | Default Upstream IP: ${UPSTREAM_HOST} | Host TLD: ${HOST_TLD} ****"
+      echo "**** Auto Proxy - Generating proxies for => Host: ${DOCKER_HOST} | Name: ${DOCKER_HOST_NAME:-N/A} | Default Upstream IP: ${UPSTREAM_HOST} | Host TLD: ${AUTO_PROXY_HOST_TLD} ****"
     fi
     . /app/auto-proxy.sh
 
@@ -40,7 +40,7 @@ fi
 
 if [ -S /var/run/docker.sock ]; then
   if [[ -v FIRST_RUN ]];then
-    echo "**** Auto Proxy - Detected docker.sock, generating proxies for => Host: Local | Name: Local | Default Upstream IP: N/A | Host TLD: ${HOST_TLD} ****"
+    echo "**** Auto Proxy - Detected docker.sock, generating proxies for => Host: Local | Name: Local | Default Upstream IP: N/A | Host TLD: ${AUTO_PROXY_HOST_TLD} ****"
   fi
   DOCKER_HOST_NAME="local"
   unset DOCKER_HOST

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/finish
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/finish
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
-sed -i '/\/app\/auto-proxy.sh/d' /config/crontabs/root
+sed -i '/\/app\/docker-wrap.sh/d' /config/crontabs/root
 rm -rf /etc/nginx/http.d/auto-proxy*.conf /config/nginx/proxy-confs/auto-proxy*.conf

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-auto-proxy-setup/run
@@ -11,9 +11,10 @@ cp /defaults/auto-proxy-readme /etc/nginx/http.d/auto-proxy-readme
 rm -rf /auto-proxy
 mkdir /auto-proxy
 
-if ! grep -q "/app/auto-proxy.sh" /config/crontabs/root; then
-    echo "*       *       *       *       *       /app/auto-proxy.sh" >> /config/crontabs/root
+if ! grep -q "/app/docker-wrap.sh" /config/crontabs/root; then
+    echo "*       *       *       *       *       /app/docker-wrap.sh" >> /config/crontabs/root
     cp /config/crontabs/root /etc/crontabs/root
 fi
 
-/app/auto-proxy.sh
+FIRST_RUN=true
+. /app/docker-wrap.sh


### PR DESCRIPTION
* generate configs using both docker.sock and DOCKER_HOST data
* parse multiple hosts from DOCKER_HOST
* enable generating swag_url with host friendly name inserted
* enable setting TLD globally or per-host
* maintain backwards compatibility with current functionality

Replicated from the updated readme:

## Multiple Hosts:

If both `DOCKER_HOST` and `docker.sock` volumes are provided this mod will detect containers using both connections. As noted in the [requirements](#requirements), containers detected via `docker.sock` must be in the same user defined network or have `swag_address` label set.

Multiple remote hosts can be used via `DOCKER_HOST` by separating hosts with a comma. Additional per-host settings can be assigned by separating with a pipe `|`. The syntax for per-host configuration:

```
host:port|friendly_name|default_tld
```


```
DOCKER_HOST=192.168.0.100:2375|serverA,192.168.0.110:2375|serverB|local.test,192.168.0.130:2375
```

* Host: `192.168.0.100:2375` -- Friendly Name: `serverA` -- TLD: `*`
* Host: `192.168.0.110:2375` -- Friendly Name: `serverB` -- TLD: `local.test`
* Host: `192.168.0.130:2375` -- Friendly Name: `host3` -- TLD: `*`

### Upstream IP and Port

When using a remote docker host from `DOCKER_HOST` auto-proxy assumes the detected containers are not on the same network as SWAG:

* If the detected containers do not have the `swag_address` label set then the Host IP will be used.
* If the detected containers do not have the `swag_port` label set then auto-proxy looks for exposed **container ports** and uses the corresponding **host port** as the upstream port. Container ports are checked in this order:
  * 80
  * 8080
  * The first mapped port, if any

### Subdomains and TLD

If a detected container does not have the `swag_url` label set then the subdomain and TLD can be programmatically generated.

The default TLD used in nginx [`server_name` directive](https://nginx.org/en/docs/http/server_names.html) can be set using `AUTO_PROXY_HOST_TLD`. This can also be set per-host using the syntax described in [`DOCKER_HOST` for `default_tld`.](#multiple-hosts)

The subdomain used for a container can optionally be modified to include the Host's `friendly_name` described in the `DOCKER_HOST` syntax by setting `AUTO_PROXY_HOST_INSERT` to either `prefix` or `suffix`

Examples using a container named `overseer`:

* Using only AUTO_PROXY_HOST_INSERT to modify subdomain
  * `DOCKER_HOST=192.168.0.100:2375|serverA`
  * `AUTO_PROXY_HOST_TLD` (not set, defaults to `*`)
  * `AUTO_PROXY_HOST_INSERT`
    * (unset) => nginx `server_name overseer.*`
    * `prefix` => nginx `server_name serverA-overseer.*`
    * `suffix` => nginx `server_name overseer-serverA.*`
* Using AUTO_PROXY_HOST_INSERT prefix and AUTO_PROXY_HOST_TLD
  * `DOCKER_HOST=192.168.0.100:2375|serverA`
  * `AUTO_PROXY_HOST_TLD=test.home`
  * `AUTO_PROXY_HOST_INSERT=prefix`
    * `server_name serverA-overseer.test.home`
* Using AUTO_PROXY_HOST_INSERT prefix and default_tld
  * `DOCKER_HOST=192.168.0.100:2375|serverA|myserver.home`
  * `AUTO_PROXY_HOST_INSERT=prefix`
    * `server_name serverA-overseer.myserver.home`
* Using AUTO_PROXY_HOST_TLD only
  * `DOCKER_HOST=192.168.0.100:2375`
  * `AUTO_PROXY_HOST_TLD=myserver.home`
    * `server_name overseer.myserver.home`