### PR TITLE
Support ro and user operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 These files are used by Linuxserver build processes to handle mods in our images. Not for end-user consumption.
 
+* **26.06.24:** - Add RO and User handlers.
 * **10.06.24:** - Move lsiown to its own file. Remove support for legacy v2 and hybrid mods.
 * **13.04.24:** - Let lsiown ignore broken symlinks (requires gnu find).
 * **26.03.24:** - Add versioning and debug logging to package install script, force venv creation when python packages are to be installed.

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -480,6 +480,14 @@ if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
         curl_check
         run_mods
     fi
+elif [[ -n ${LSIO_READ_ONLY_FS} ]] && [[ -n ${LSIO_NON_ROOT_USER} ]]; then
+echo "╔═════════════════════════════════════════════════════════════════════════╗
+║                                                                         ║
+║    You are running this container read-only and as a non-root user:     ║
+║              This combination of settings is not supported              ║
+║                  and may result in unwanted behaviour.                  ║
+║                                                                         ║
+╚═════════════════════════════════════════════════════════════════════════╝"
 elif [[ -n ${LSIO_READ_ONLY_FS} ]]; then
 echo "╔═════════════════════════════════════════════════════════════════════════╗
 ║                                                                         ║
@@ -493,14 +501,6 @@ echo "╔═══════════════════════�
 ║           You are running this container as a non-root user:            ║
 ║   UMASK, custom services, & docker mod functionality will be disabled   ║
 ║      and the PUID/PGID environment variables will have no effect.       ║
-║                                                                         ║
-╚═════════════════════════════════════════════════════════════════════════╝"
-else
-echo "╔═════════════════════════════════════════════════════════════════════════╗
-║                                                                         ║
-║    You are running this container read-only and as a non-root user:     ║
-║              This combination of settings is not supported              ║
-║                  and may result in unwanted behaviour.                  ║
 ║                                                                         ║
 ╚═════════════════════════════════════════════════════════════════════════╝"
 fi

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -493,6 +493,7 @@ echo "╔═══════════════════════�
 ║                                                                         ║
 ║                You are running this container read-only:                ║
 ║   UMASK, custom services, & docker mod functionality will be disabled   ║
+║      and the PUID/PGID environment variables will have no effect.       ║
 ║                                                                         ║
 ╚═════════════════════════════════════════════════════════════════════════╝"
 elif [[ -n ${LSIO_NON_ROOT_USER} ]]; then

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -480,12 +480,27 @@ if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
         curl_check
         run_mods
     fi
-
+elif [[ -n ${LSIO_READ_ONLY_FS} ]]; then
+echo "╔═════════════════════════════════════════════════════════════════════════╗
+║                                                                         ║
+║                You are running this container read-only:                ║
+║   UMASK, custom services, & docker mod functionality will be disabled   ║
+║                                                                         ║
+╚═════════════════════════════════════════════════════════════════════════╝"
+elif [[ -n ${LSIO_NON_ROOT_USER} ]]; then
+echo "╔═════════════════════════════════════════════════════════════════════════╗
+║                                                                         ║
+║           You are running this container as a non-root user:            ║
+║   UMASK, custom services, & docker mod functionality will be disabled   ║
+║      and the PUID/PGID environment variables will have no effect.       ║
+║                                                                         ║
+╚═════════════════════════════════════════════════════════════════════════╝"
 else
 echo "╔═════════════════════════════════════════════════════════════════════════╗
 ║                                                                         ║
-║     You are running this container read-only or as a non-root user:     ║
-║   UMASK, custom services, & docker mod functionality will be disabled   ║
+║    You are running this container read-only and as a non-root user:     ║
+║              This combination of settings is not supported              ║
+║                  and may result in unwanted behaviour.                  ║
 ║                                                                         ║
 ╚═════════════════════════════════════════════════════════════════════════╝"
 fi

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -7,7 +7,7 @@
 # 2022-09-25 - Initial Release
 # 2024-04-13 - Let lsiown ignore broken symlinks (requires gnu find)
 # 2024-06-12 - Remove lsiown and legacy s6 handlers
-MOD_SCRIPT_VER="3.20240612"
+MOD_SCRIPT_VER="3.20240613"
 
 # Define custom folder paths
 SCRIPTS_DIR="/custom-cont-init.d"
@@ -434,7 +434,7 @@ run_mods_local() {
 
 run_branding() {
   # intentional tabs in the heredoc
-  cat <<-EOF >/etc/s6-overlay/s6-rc.d/init-adduser/branding
+  cat <<-EOF | tee /run/branding /etc/s6-overlay/s6-rc.d/init-adduser/branding > /dev/null 2>&1
 	───────────────────────────────────────
 
 	      ██╗     ███████╗██╗ ██████╗
@@ -449,23 +449,43 @@ run_branding() {
 	EOF
 }
 
-# Run alias creation functions
-create_with_contenv_alias
-
 # Main script loop
-if [[ -d "${SCRIPTS_DIR}" ]] || [[ -d "${SERVICES_DIR}" ]]; then
-    tamper_check
-    process_custom_services
+if grep -qEe ' / \w+ ro' /proc/mounts; then
+    printf '1' > /run/s6/container_environment/LSIO_READ_ONLY_FS
+    LSIO_READ_ONLY_FS=1
 fi
 
-# Run mod logic
-if [[ -n "${DOCKER_MODS+x}" ]] && [[ "${DOCKER_MODS_SIDELOAD,,}" = "true" ]]; then
-    run_mods_local
-elif [[ -n "${DOCKER_MODS+x}" ]]; then
-    curl_check
-    run_mods
+if [[ ! $(stat /run -c %u) == "0" ]]; then
+    printf '1' > /run/s6/container_environment/LSIO_NON_ROOT_USER
+    LSIO_NON_ROOT_USER=1
 fi
 
 if [[ "${LSIO_FIRST_PARTY}" = "true" ]]; then
     run_branding
+fi
+
+if [[ -z ${LSIO_READ_ONLY_FS} ]] && [[ -z ${LSIO_NON_ROOT_USER} ]]; then
+    # Run alias creation functions
+    create_with_contenv_alias
+
+    if [[ -d "${SCRIPTS_DIR}" ]] || [[ -d "${SERVICES_DIR}" ]]; then
+        tamper_check
+        process_custom_services
+    fi
+
+    # Run mod logic
+    if [[ -n "${DOCKER_MODS+x}" ]] && [[ "${DOCKER_MODS_SIDELOAD,,}" = "true" ]]; then
+        run_mods_local
+    elif [[ -n "${DOCKER_MODS+x}" ]]; then
+        curl_check
+        run_mods
+    fi
+
+else
+echo "╔═════════════════════════════════════════════════════════════════════════╗
+║                                                                         ║
+║     You are running this container read-only or as a non-root user:     ║
+║   UMASK, custom services, & docker mod functionality will be disabled   ║
+║                                                                         ║
+╚═════════════════════════════════════════════════════════════════════════╝"
 fi

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -7,7 +7,7 @@
 # 2022-09-25 - Initial Release
 # 2024-04-13 - Let lsiown ignore broken symlinks (requires gnu find)
 # 2024-06-12 - Remove lsiown and legacy s6 handlers
-MOD_SCRIPT_VER="3.20240613"
+MOD_SCRIPT_VER="3.20240626"
 
 # Define custom folder paths
 SCRIPTS_DIR="/custom-cont-init.d"


### PR DESCRIPTION
These are a set of core changes required to support read-only operation with some downstream images. It also lays the groundwork for potential support of --user with s6 3.2. Also requires some changes to the base images (see https://github.com/linuxserver/docker-baseimage-alpine/pull/246 for example), both can be merged independently without breaking anything.

If testing, /run needs to be mounted to tmpfs with exec, and to stop warnings in the logs currently /var/spool/cron/crontabs also needs to be mounted to tmpfs.