### PR TITLE
universal-calibre: update packages for noble compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ## Buildstage ##
-FROM ghcr.io/linuxserver/baseimage-alpine:3.19 as buildstage
+FROM ghcr.io/linuxserver/baseimage-alpine:3.19 AS buildstage
 
 ARG MOD_VERSION
 

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-universal-calibre-add-package/run
@@ -34,7 +34,7 @@ if ! dpkg -s xz-utils >/dev/null 2>&1; then
 fi
 
 if [ ! -L /usr/lib/x86_64-linux-gnu/libGL.so.1 ]; then
-    PACKAGES="libgl1-mesa-glx ${PACKAGES}"
+    PACKAGES="libgl1 libglx-mesa0 ${PACKAGES}"
 fi
 
 if [ ! -L /usr/lib/x86_64-linux-gnu/libxdamage.so.1 ]; then


### PR DESCRIPTION
`libgl1-mesa-glx` is a dummy package on jammy and below for installing 2 deps. It doesn't exist on noble, so we install the 2 deps directly instead of the dummy.

fixes #938 