### PR TITLE
Allow sideloaded directories, fix shafile check

### DIFF
--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -399,7 +399,7 @@ run_mods_local() {
     for DOCKER_MOD in $(echo "${DOCKER_MODS}" | tr '|' '\n'); do
         # Check mod file exists
         if [[ -f "/mods/${DOCKER_MOD}.tar" ]]; then
-            # Caculate mod bits
+            # Calculate mod bits
             FILENAME="${DOCKER_MOD}.local"
             SHALAYER=$(sha256sum "/mods/${DOCKER_MOD}.tar" | cut -d " " -f 1)
             write_mod_debug "Mod checksum is ${SHALAYER}"
@@ -425,7 +425,7 @@ run_mods_local() {
                 write_mod_info "${DOCKER_MOD} applied to container"
             fi
         elif [[ -d "/mods/${DOCKER_MOD}" ]]; then
-            # Caculate mod bits
+            # Calculate mod bits
             FILENAME="${DOCKER_MOD}.local"
             SHALAYER=$(tar c "/mods/${DOCKER_MOD}"  2>/dev/null | sha256sum | cut -d " " -f 1)
             write_mod_debug "Mod checksum is ${SHALAYER}"

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -5,9 +5,7 @@
 
 # Version 3
 # 2022-09-25 - Initial Release
-# 2024-04-13 - Let lsiown ignore broken symlinks (requires gnu find)
-# 2024-06-12 - Remove lsiown and legacy s6 handlers
-MOD_SCRIPT_VER="3.20240626"
+MOD_SCRIPT_VER="3.20240928"
 
 # Define custom folder paths
 SCRIPTS_DIR="/custom-cont-init.d"
@@ -400,18 +398,18 @@ run_mods_local() {
     write_mod_info "Running Local Docker Modification Logic"
     for DOCKER_MOD in $(echo "${DOCKER_MODS}" | tr '|' '\n'); do
         # Check mod file exists
-        if [[ -n "$(/bin/ls -A "/mods/${DOCKER_MOD}.tar" 2>/dev/null)" ]]; then
+        if [[ -f "/mods/${DOCKER_MOD}.tar" ]]; then
             # Caculate mod bits
             FILENAME="${DOCKER_MOD}.local"
             SHALAYER=$(sha256sum "/mods/${DOCKER_MOD}.tar" | cut -d " " -f 1)
+            write_mod_debug "Mod checksum is ${SHALAYER}"
             # Check if we have allready applied this layer
             if [[ -f "/${FILENAME}" ]] && [[ "${SHALAYER}" == "$(cat /"${FILENAME}")" ]]; then
                 write_mod_info "${DOCKER_MOD} at ${SHALAYER} has been previously applied, skipping"
             else
-                write_mod_info "Installing ${DOCKER_MOD}"
+                write_mod_info "Installing ${DOCKER_MOD} from /mods/${DOCKER_MOD}.tar"
                 mkdir -p "/tmp/mod/${DOCKER_MOD}"
-                tar xf "/mods/${DOCKER_MOD}.tar" -C /tmp/mod --strip-components=1
-                tar xf "/tmp/mod/layer.tar" -C "/tmp/mod/${DOCKER_MOD}"
+                tar xf "/mods/${DOCKER_MOD}.tar" -C "/tmp/mod/${DOCKER_MOD}"
                 # Remove any v2 mod elements as they're no longer supported
                 if [[ -d "/tmp/mod/${DOCKER_MOD}/etc/cont-init.d" ]]; then
                     rm -rf "/tmp/mod/${DOCKER_MOD}/etc/cont-init.d"
@@ -423,11 +421,37 @@ run_mods_local() {
                 cp -R "/tmp/mod/${DOCKER_MOD}"/* /
                 shopt -u dotglob
                 rm -rf "/tmp/mod/${DOCKER_MOD}"
-                echo "${SHALAYER}" >"/${FILENAME}.local"
+                echo "${SHALAYER}" >"/${FILENAME}"
+                write_mod_info "${DOCKER_MOD} applied to container"
+            fi
+        elif [[ -d "/mods/${DOCKER_MOD}" ]]; then
+            # Caculate mod bits
+            FILENAME="${DOCKER_MOD}.local"
+            SHALAYER=$(tar c "/mods/${DOCKER_MOD}"  2>/dev/null | sha256sum | cut -d " " -f 1)
+            write_mod_debug "Mod checksum is ${SHALAYER}"
+            # Check if we have allready applied this layer
+            if [[ -f "/${FILENAME}" ]] && [[ "${SHALAYER}" == "$(cat /"${FILENAME}")" ]]; then
+                write_mod_info "${DOCKER_MOD} at ${SHALAYER} has been previously applied, skipping"
+            else
+                write_mod_info "Installing ${DOCKER_MOD} from /mods/${DOCKER_MOD}/"
+                mkdir -p "/tmp/mod/${DOCKER_MOD}"
+                cp -R "/mods/${DOCKER_MOD}" "/tmp/mod/"
+                # Remove any v2 mod elements as they're no longer supported
+                if [[ -d "/tmp/mod/${DOCKER_MOD}/etc/cont-init.d" ]]; then
+                    rm -rf "/tmp/mod/${DOCKER_MOD}/etc/cont-init.d"
+                fi
+                if [[ -d "/tmp/mod/${DOCKER_MOD}/etc/services.d" ]]; then
+                    rm -rf "/tmp/mod/${DOCKER_MOD}/etc/services.d"
+                fi
+                shopt -s dotglob
+                cp -R "/tmp/mod/${DOCKER_MOD}"/* /
+                shopt -u dotglob
+                rm -rf "/tmp/mod/${DOCKER_MOD}"
+                echo "${SHALAYER}" >"/${FILENAME}"
                 write_mod_info "${DOCKER_MOD} applied to container"
             fi
         else
-            write_mod_error "${DOCKER_MOD}.tar not found in /mods, skipping"
+            write_mod_error "${DOCKER_MOD} not found in /mods, skipping"
         fi
     done
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Sideloading requires building a mod using something like `docker buildx build -o - . > /tmp/mod/universal-tshoot.tar` as `docker save` will give you an OCI layer tarball that we can't parse and `docker export` requires a running container, which gives you a lot of extra crap we don't want.

Sideloading from a dir is designed to accommodate #956 and behaves exactly the same way except it looks for `/mods/<mod name>` as a directory containing the mod image root filesystem rather than `/mods/<modname>.tar`

Also I'd fat-fingered the SHA file so it was saving to .local.local and so never properly checking on a restart. Not that anyone should really be using this in production anyway.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
