### PR TITLE
Update README to mirror easier crowdsec api key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ If adding multiple mods, enter them in an array separated by `|`, such as `DOCKE
 
 If running CrowdSec in a container it must be on a common docker network with SWAG.
 
-Generate an API key for the bouncer with `cscli bouncers add bouncer-swag` or `docker exec -t crowdsec cscli bouncers add bouncer-swag`, if you're running CrowdSec in a container.
+You have 2 options to generate a Crowdsec API key:
 
-Make a note of the API key as you can't retrieve it later without removing and re-adding the bouncer.
+1. Create an arbitrary string and pass it as the `BOUNCER_KEY_swag` environment variable in your crowdsec image
+2. Generate an API key for the bouncer with `cscli bouncers add bouncer-swag` or `docker exec -t crowdsec cscli bouncers add bouncer-swag`, if you're running CrowdSec in a container. Make a note of the API key as you can't retrieve it later without removing and re-adding the bouncer.
 
 Set the following environment variables on your SWAG container.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Update README to reflect changes following [this PR](https://github.com/crowdsecurity/crowdsec/pull/1341).
Crowdsec API keys can now be generated outside of crowdsec and fed to both `crowdsec` and `swag-crowdsec` via environement variables, removing a step and simplifying the setup.

## Benefits of this PR and context:
Guides users to pass an arbitrary string as the crowdsec-swag API key to both the crowdsec and swag images, thus removing the need to generate the API key from crowdsec.


## How Has This Been Tested?
Crowdsec-side update should already have been tested in the [previously mentioned PR](https://github.com/crowdsecurity/crowdsec/pull/1341).

I created a new docker compose file, added the `CROWDSEC_API_KEY` env variable to one, and `BOUNCER_KEY_swag` to the other. Built and ran the containers and both ran fine, correctly reporting the bouncer had been registered.

Ran on DSM 7


## Source / References:
https://github.com/crowdsecurity/crowdsec/pull/1341
https://www.linuxserver.io/blog/blocking-malicious-connections-with-crowdsec-and-swag
