### PR TITLE
Add legacy1 debs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   if [ -z "${MOD_VERSION}" ]; then \
     MOD_VERSION=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/latest" | jq -r '.tag_name'); \
   fi && \
-  COMP_RT_URLS_LEGACY1=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/tags/24.35.30872.22" | jq -r '.body' | grep wget | grep legacy1 | grep -v .sum | grep -v .ddeb | sed 's|wget ||g') && \
+  COMP_RT_URLS_LEGACY1=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/tags/24.35.30872.22" | jq -r '.body' | grep wget | grep -v .sum | grep -v .ddeb | sed 's|wget ||g') && \
   echo "**** grab legacy1 debs ****" && \
   mkdir -p /root-layer/opencl-intel-legacy1 && \
   for i in $COMP_RT_URLS_LEGACY1; do \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,17 @@ RUN \
   if [ -z "${MOD_VERSION}" ]; then \
     MOD_VERSION=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/latest" | jq -r '.tag_name'); \
   fi && \
+  COMP_RT_URLS_LEGACY1=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/tags/24.35.30872.22" | jq -r '.body' | grep wget | grep legacy1 | grep -v .sum | grep -v .ddeb | sed 's|wget ||g') && \
+  echo "**** grab legacy1 debs ****" && \
+  mkdir -p /root-layer/opencl-intel-legacy1 && \
+  for i in $COMP_RT_URLS_LEGACY1; do \
+    echo "**** downloading ${i%$'\r'} ****" && \
+    curl -fS --retry 3 --retry-connrefused -o \
+      /root-layer/opencl-intel-legacy1/$(basename "${i%$'\r'}") -L \
+      "${i%$'\r'}" || exit 1; \
+  done && \
   COMP_RT_URLS=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/tags/${MOD_VERSION}" | jq -r '.body' | grep wget | grep -v .sum | grep -v .ddeb | sed 's|wget ||g') && \
-  echo "**** grab debs ****" && \
+  echo "**** grab latest debs ****" && \
   mkdir -p /root-layer/opencl-intel && \
   for i in $COMP_RT_URLS; do \
     echo "**** downloading ${i%$'\r'} ****" && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,3 @@ This mod adds opencl-intel to jellyfin, to be installed/updated during container
 In jellyfin docker arguments, set an environment variable `DOCKER_MODS=linuxserver/mods:jellyfin-opencl-intel`
 
 If adding multiple mods, enter them in an array separated by `|`, such as `DOCKER_MODS=linuxserver/mods:jellyfin-opencl-intel|linuxserver/mods:jellyfin-mod2`
-
-If your system is equipped with an older CPU, you will need to pin the Opencl-Intel mod to a specific version.  Intel has deprecated support for "legacy" CPUs with pre-Tigerlake GPUs.  This includes desktop CPUs prior to Rocketlake, laptop CPUs prior to Tigerlake, and low power CPUs prior to Alderlake-N.  If you are unsure which CPU family you have, if your iGPU model number is in the 500 and 600 range, you have a "legacy" Intel CPU.
-
-For legacy CPUs, you must pin the Opencl-Intel mod to version 24.35.30872.22.  Versions newer than this will cause tone mapping in Jellyfin to fail due to the openCL runtime not supporting your legacy CPU.  Appending the environment variable with the version number will install that specific version.  `DOCKER_MODS=linuxserver/mods:jellyfin-opencl-intel-24.35.30872.22`

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-opencl-intel-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-opencl-intel-add-package/run
@@ -11,6 +11,15 @@ if [ $(uname -m) != "x86_64" ]; then
     exit 0
 fi
 
+if [ -d /opencl-intel-legacy ]; then
+    echo "**** Installing/updating opencl-intel legacy1 debs and adding clinfo to package install list ****"
+    dpkg -i /opencl-intel-legacy/*.deb
+    rm -rf /opencl-intel-legacy
+    echo "clinfo" >> /mod-repo-packages-to-install.list
+else
+    echo "**** Opencl-intel already installed ****"
+fi
+
 if [ -d /opencl-intel ]; then
     echo "**** Installing/updating opencl-intel debs and adding clinfo to package install list ****"
     dpkg -i /opencl-intel/*.deb

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-opencl-intel-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-jellyfin-opencl-intel-add-package/run
@@ -11,13 +11,13 @@ if [ $(uname -m) != "x86_64" ]; then
     exit 0
 fi
 
-if [ -d /opencl-intel-legacy ]; then
+if [ -d /opencl-intel-legacy1 ]; then
     echo "**** Installing/updating opencl-intel legacy1 debs and adding clinfo to package install list ****"
-    dpkg -i /opencl-intel-legacy/*.deb
-    rm -rf /opencl-intel-legacy
+    dpkg -i /opencl-intel-legacy1/*.deb
+    rm -rf /opencl-intel-legacy1
     echo "clinfo" >> /mod-repo-packages-to-install.list
 else
-    echo "**** Opencl-intel already installed ****"
+    echo "**** Opencl-intel-legacy1 already installed ****"
 fi
 
 if [ -d /opencl-intel ]; then


### PR DESCRIPTION
Intel [separated support for opencl pre-gen12](https://github.com/intel/compute-runtime/blob/master/LEGACY_PLATFORMS.md) and created packages called legacy1.
The legacy packages [can now co-exist with latest](https://github.com/intel/compute-runtime/issues/770).
Regarding legacy being a moving target, they have named pre-gen12 legacy1, and future legacy packages will be named legacy2, legacy3, etc.