### PR TITLE
Support pulling mod by manifest hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 These files are used by Linuxserver build processes to handle mods in our images. Not for end-user consumption.
 
+* **31.12.24:** - Support pulling mods using manifest hash.
 * **22.12.24:** - Add modcache support.
 * **26.06.24:** - Add RO and User handlers.
 * **10.06.24:** - Move lsiown to its own file. Remove support for legacy v2 and hybrid mods.

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -12,7 +12,7 @@ SCRIPTS_DIR="/custom-cont-init.d"
 SERVICES_DIR="/custom-services.d"
 
 if [[ ${DOCKER_MODS_DEBUG_CURL,,} = "true" ]]; then
-    CURL_NOISE_LEVEL="-v"
+    CURL_NOISE_LEVEL="-vs"
 else
     CURL_NOISE_LEVEL="--silent"
 fi

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -5,7 +5,7 @@
 
 # Version 3
 # 2022-09-25 - Initial Release
-MOD_SCRIPT_VER="3.20241223"
+MOD_SCRIPT_VER="3.20241231"
 
 # Define custom folder paths
 SCRIPTS_DIR="/custom-cont-init.d"
@@ -298,15 +298,20 @@ run_mods() {
         ENDPOINT="${DOCKER_MOD%%:*}"
         USERNAME="${DOCKER_MOD%%/*}"
         REPO="${ENDPOINT#*/}"
-        TAG="${DOCKER_MOD#*:}"
+        FULLTAG="${DOCKER_MOD#*:}"
+        TAG="${FULLTAG%@*}"
+        TAGSHA="${DOCKER_MOD#*@}"
+        if [[ ! "${TAGSHA}" =~ sha256 ]]; then
+            unset TAGSHA
+        fi
         if [[ "${TAG}" == "${DOCKER_MOD}" ]]; then
             TAG="latest"
         fi
-        FILENAME="${USERNAME}.${REPO}.${TAG}"
+        FILENAME="${USERNAME}.${REPO}.${TAG}${TAGSHA:+.${TAGSHA#*:}}"
         MANIFEST_URL="https://${REGISTRY}/v2/${ENDPOINT}/manifests"
         BLOB_URL="https://${REGISTRY}/v2/${ENDPOINT}/blobs/"
-        MOD_UA="Mozilla/5.0 (Linux $(uname -m)) linuxserver.io ${REGISTRY}/${ENDPOINT}:${TAG}"
-        write_mod_debug "Registry='${REGISTRY}', Repository='${USERNAME}', Image='${ENDPOINT}', Tag='${TAG}'"
+        MOD_UA="Mozilla/5.0 (Linux $(uname -m)) linuxserver.io ${REGISTRY}/${ENDPOINT}:${TAG}${TAGSHA:+@$TAGSHA}"
+        write_mod_debug "Registry='${REGISTRY}', Repository='${USERNAME}', Image='${ENDPOINT}', Tag='${TAG}', TagSHA='${TAGSHA:-N/A}'"
         case "${REGISTRY}" in
             "lscr.io") AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull";;
             "ghcr.io") AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull";;
@@ -360,7 +365,7 @@ run_mods() {
             MOD_OFFLINE="true"
         else
             # Determine first and only layer of image
-            SHALAYER=$(get_blob_sha "${TOKEN}" "${MANIFEST_URL}" "${TAG}" "${ARCH:--amd64}")
+            SHALAYER=$(get_blob_sha "${TOKEN}" "${MANIFEST_URL}" "${TAGSHA:-$TAG}" "${ARCH:--amd64}")
             if [[ $? -eq 1 ]]; then
                 write_mod_error "No manifest available for arch ${ARCH:--amd64}, cannot fetch mod"
                 continue

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -295,29 +295,43 @@ run_mods() {
             fi
             ;;
         esac
-        ENDPOINT="${DOCKER_MOD%%:*}"
-        USERNAME="${DOCKER_MOD%%/*}"
-        REPO="${ENDPOINT#*/}"
-        FULLTAG="${DOCKER_MOD#*:}"
-        TAG="${FULLTAG%@*}"
-        TAGSHA="${DOCKER_MOD#*@}"
-        if [[ ! "${TAGSHA}" =~ sha256: ]]; then
+        # Identify what kind of image name format we're working with
+        if [[ ${DOCKER_MOD} == *:*@* ]]; then
+            ENDPOINT="${DOCKER_MOD%%:*}"
+            USERNAME="${DOCKER_MOD%%/*}"
+            REPO="${ENDPOINT#*/}"
+            FULLTAG="${DOCKER_MOD#*:}"
+            TAG="${FULLTAG%@*}"
+            TAGSHA="${DOCKER_MOD#*@}"
+        elif [[ ${DOCKER_MOD} == *@* ]]; then
+            ENDPOINT="${DOCKER_MOD%%@*}"
+            USERNAME="${DOCKER_MOD%%/*}"
+            REPO="${ENDPOINT#*/}"
+            unset FULLTAG
+            unset TAG
+            TAGSHA="${DOCKER_MOD#*@}"
+        elif [[ ${DOCKER_MOD} == *:* ]]; then
+            ENDPOINT="${DOCKER_MOD%%:*}"
+            USERNAME="${DOCKER_MOD%%/*}"
+            REPO="${ENDPOINT#*/}"
+            unset FULLTAG
+            TAG="${DOCKER_MOD#*:}"
             unset TAGSHA
         fi
         if [[ "${TAG}" == "${DOCKER_MOD}" ]]; then
             TAG="latest"
         fi
-        FILENAME="${USERNAME}.${REPO}.${TAG}${TAGSHA:+.${TAGSHA#*:}}"
+        FILENAME="${USERNAME}.${REPO}${TAG:+.${TAG}}${TAGSHA:+.${TAGSHA#*:}}"
         MANIFEST_URL="https://${REGISTRY}/v2/${ENDPOINT}/manifests"
         BLOB_URL="https://${REGISTRY}/v2/${ENDPOINT}/blobs/"
-        MOD_UA="Mozilla/5.0 (Linux $(uname -m)) linuxserver.io ${REGISTRY}/${ENDPOINT}:${TAG}${TAGSHA:+@$TAGSHA}"
-        write_mod_debug "Registry='${REGISTRY}', Repository='${USERNAME}', Image='${ENDPOINT}', Tag='${TAG}', TagSHA='${TAGSHA:-N/A}'"
+        MOD_UA="Mozilla/5.0 (Linux $(uname -m)) linuxserver.io ${REGISTRY}/${ENDPOINT}${TAG:+:${TAG}}${TAGSHA:+@${TAGSHA}}"
+        write_mod_debug "Registry='${REGISTRY}', Repository='${USERNAME}', Image='${ENDPOINT}', Tag='${TAG:-N/A}', TagSHA='${TAGSHA:-N/A}'"
         case "${REGISTRY}" in
             "lscr.io") AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull";;
             "ghcr.io") AUTH_URL="https://ghcr.io/token?scope=repository%3A${USERNAME}%2F${REPO}%3Apull";;
             "quay.io") AUTH_URL="https://quay.io/v2/auth?service=quay.io&scope=repository%3A${USERNAME}%2F${REPO}%3Apull";;
             "registry-1.docker.io") AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${ENDPOINT}:pull";;
-            *) AUTH_URL=$(get_auth_url "${MANIFEST_URL}" "${TAG}")
+            *) AUTH_URL=$(get_auth_url "${MANIFEST_URL}" "${TAG:-${TAGSHA}}")
         esac
         # Kill off modification logic if any of the usernames are banned
         for BANNED in $(curl -s https://raw.githubusercontent.com/linuxserver/docker-mods/master/blacklist.txt); do
@@ -344,7 +358,7 @@ run_mods() {
         write_mod_info "Adding ${DOCKER_MOD} to container"
         # If we're using lscr try and get the manifest from ghcr, if it fails re-request a token from Docker Hub
         if [[ "${REGISTRY}" == "lscr.io" ]]; then
-            if [[ -n $(curl --user-agent "${MOD_UA}" -sLH "Authorization: Bearer ${TOKEN}" "${MANIFEST_URL}/${TAG}" | jq -r '.errors' >/dev/null 2>&1) ]]; then
+            if [[ -n $(curl --user-agent "${MOD_UA}" -sLH "Authorization: Bearer ${TOKEN}" "${MANIFEST_URL}/${TAG:-${TAGSHA}}" | jq -r '.errors' >/dev/null 2>&1) ]]; then
                 write_mod_debug "Couldn't fetch manifest from ghcr.io, trying docker.io"
                 AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${ENDPOINT}:pull"
                 TOKEN="$(

--- a/docker-mods.v3
+++ b/docker-mods.v3
@@ -301,7 +301,7 @@ run_mods() {
         FULLTAG="${DOCKER_MOD#*:}"
         TAG="${FULLTAG%@*}"
         TAGSHA="${DOCKER_MOD#*@}"
-        if [[ ! "${TAGSHA}" =~ sha256 ]]; then
+        if [[ ! "${TAGSHA}" =~ sha256: ]]; then
             unset TAGSHA
         fi
         if [[ "${TAG}" == "${DOCKER_MOD}" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Closes #922 

~~Further work needed to support a wider range of formats for the mods as currently it only works with the `mods:tag@sha256:hash` format and not `mods@sha256:hash` format.~~

## Benefits of this PR and context:
Given the following inputs for DOCKER_MODS:
```text
linuxserver/mods:universal-tshoot@sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
linuxserver/mods@sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
linuxserver/mods:universal-tshoot
```
The data is parsed as:
```text
$ENDPOINT         $USERNAME     $REPO   $FULLTAG                                                                                  $TAG              $TAGSHA
linuxserver/mods  linuxserver   mods    universal-tshoot@sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98  universal-tshoot  sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
linuxserver/mods  linuxserver   mods                                                                                                                sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
linuxserver/mods  linuxserver   mods                                                                                              universal-tshoot
```
And then correctly fetched from the remote registry and saved as:
```
linuxserver.mods.universal-tshoot.d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98.tar.xz
linuxserver.mods.d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98.tar.xz
linuxserver.mods.universal-tshoot.tar.xz
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
Note that technically when supplying a SHA hash the tag is not used by the docker CLI, thus all of the following will result in the same image being fetched:
```
linuxserver/mods:universal-tshoot@sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
linuxserver/mods@sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
linuxserver/mods:foo@sha256:d31f2d4a88a0c5d98f6bf7f4725e228959b6d22dcd14d44c7a755521f007cd98
```
*But* from a mod perspective they're treated as 3 different mods because of how we store the data about them (Layer SHA, not manifest SHA).
