### PR TITLE
Fixed package descriptions for firefox-fonts mod

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mod-firefox-fonts-add-package/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-firefox-fonts-add-package/run
@@ -1,12 +1,12 @@
 #!/usr/bin/with-contenv bash
 
-if ! apk info --installed ttf-dejavu >/dev/null; then
+if ! dpkg -s fonts-dejavu >/dev/null; then
     echo "**** Adding firefox-fonts packages to install list ****"
     echo "\
-        ttf-dejavu \
-        font-noto-emoji \
-        font-noto-cjk \
-        font-croscore" >> /mod-repo-packages-to-install.list
+        fonts-dejavu \
+        fonts-noto-color-emoji \
+        fonts-noto-cjk \
+        fonts-croscore >> /mod-repo-packages-to-install.list
 else
     echo "**** Firefox-fonts packages already installed, skipping ****"
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

This PR fixes issue #1007 by using the correct package names for downloading the extra fonts. I also corrected the command for checking if the mod has already been installed. Note that this does not address the deprecation warning, but it does restore the intended functionality to the firefox-fonts mod.

## Benefits of this PR and context:

This PR enables users of the firefox-fonts mod to have CJK fonts automatically installed in their firefox container, whereas before this functionality was broken. This fixes issue #1007, but does so without addressing the deprecation warning, because the "mozillateam" PPA has nothing to do with the firefox-fonts mod and must be fixed in the [docker-firefox](https://github.com/linuxserver/docker-firefox) repository.

## How Has This Been Tested?

1. I forked the repository and implemented the changes on [my copy of the firefox-fonts branch](https://github.com/bell345/docker-mods/tree/firefox-fonts).
2. I enabled the GitHub action for pushing a new Docker image, added secrets corresponding to my own Docker account, and changed the name of the repo in [`.github/workflows/BuildImage.yml`](https://github.com/bell345/docker-mods/blob/firefox-fonts/.github/workflows/BuildImage.yml).
3. This created the Docker image [`sigptr/mods:firefox-fonts`](https://hub.docker.com/repository/docker/sigptr/mods/tags/firefox-fonts/sha256-1df8730f8a3539955fb4129cf55e59d44324efa2a8bd1dc5c7eb6290c46438dd) on Dockerhub.
4. On my Unraid instance where I run a Firefox container, I changed the value of the `DOCKER_MODS` variable to `sigptr/mods:firefox-fonts`
5. After restarting my container, I verified in the logs that the correct packages were being installed:
```
W: https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/dists/noble/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
_XSERVTransmkdir: ERROR: euid != 0,directory /tmp/.X11-unix will not be created.

Xvnc KasmVNC 1.3.3 - built Jan 18 2025 18:59:40
Copyright (C) 1999-2018 KasmVNC Team and many others (see README.me)
See http://kasmweb.com for information on KasmVNC.
Underlying X server release 12101012

The XKEYBOARD keymap compiler (xkbcomp) reports:
> Warning:          Could not resolve keysym XF86CameraAccessEnable
> Warning:          Could not resolve keysym XF86CameraAccessDisable
> Warning:          Could not resolve keysym XF86CameraAccessToggle
> Warning:          Could not resolve keysym XF86NextElement
> Warning:          Could not resolve keysym XF86PreviousElement
> Warning:          Could not resolve keysym XF86AutopilotEngageToggle
> Warning:          Could not resolve keysym XF86MarkWaypoint
> Warning:          Could not resolve keysym XF86Sos
> Warning:          Could not resolve keysym XF86NavChart
> Warning:          Could not resolve keysym XF86FishingChart
> Warning:          Could not resolve keysym XF86SingleRangeRadar
> Warning:          Could not resolve keysym XF86DualRangeRadar
> Warning:          Could not resolve keysym XF86RadarOverlay
> Warning:          Could not resolve keysym XF86TraditionalSonar
> Warning:          Could not resolve keysym XF86ClearvuSonar
> Warning:          Could not resolve keysym XF86SidevuSonar
> Warning:          Could not resolve keysym XF86NavInfo
Errors from xkbcomp are not fatal to the X server
[mi] mieq: warning: overriding existing handler (nil) with 0x561f7a81e930 for event 2
[mi] mieq: warning: overriding existing handler (nil) with 0x561f7a81e930 for event 3
MESA: error: ZINK: failed to choose pdev
glx: failed to create drisw screen
 2025-01-20 12:24:50,962 [INFO] websocket 0: got client connection from 127.0.0.1
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
fonts-noto-color-emoji is already the newest version (2.042-1).
The following additional packages will be installed:
  fonts-dejavu-core fonts-dejavu-extra fonts-dejavu-mono
Suggested packages:
  fonts-crosextra-caladea fonts-crosextra-carlito
The following NEW packages will be installed:
  fonts-croscore fonts-dejavu fonts-dejavu-core fonts-dejavu-extra
  fonts-dejavu-mono fonts-noto-cjk fonts-noto-cjk-extra
0 upgraded, 7 newly installed, 0 to remove and 0 not upgraded.
Need to get 211 MB of archives.
After this operation, 329 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu noble/universe amd64 fonts-croscore all 20201225-2 [1,709 kB]
Get:2 http://archive.ubuntu.com/ubuntu noble/main amd64 fonts-dejavu-mono all 2.37-8 [502 kB]
Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 fonts-dejavu-core all 2.37-8 [835 kB]
Get:4 http://archive.ubuntu.com/ubuntu noble/main amd64 fonts-dejavu-extra all 2.37-8 [1,947 kB]
Get:5 http://archive.ubuntu.com/ubuntu noble/universe amd64 fonts-dejavu all 2.37-8 [3,020 B]
Get:6 http://archive.ubuntu.com/ubuntu noble/main amd64 fonts-noto-cjk all 1:20230817+repack1-3 [61.2 MB]
Get:7 http://archive.ubuntu.com/ubuntu noble/main amd64 fonts-noto-cjk-extra all 1:20230817+repack1-3 [145 MB]
Fetched 211 MB in 21s (10.2 MB/s)
Selecting previously unselected package fonts-croscore.
(Reading database ... 46559 files and directories currently installed.)
Preparing to unpack .../0-fonts-croscore_20201225-2_all.deb ...
Unpacking fonts-croscore (20201225-2) ...
Selecting previously unselected package fonts-dejavu-mono.
Preparing to unpack .../1-fonts-dejavu-mono_2.37-8_all.deb ...
Unpacking fonts-dejavu-mono (2.37-8) ...
Selecting previously unselected package fonts-dejavu-core.
Preparing to unpack .../2-fonts-dejavu-core_2.37-8_all.deb ...
Unpacking fonts-dejavu-core (2.37-8) ...
Selecting previously unselected package fonts-dejavu-extra.
Preparing to unpack .../3-fonts-dejavu-extra_2.37-8_all.deb ...
Unpacking fonts-dejavu-extra (2.37-8) ...
Selecting previously unselected package fonts-dejavu.
Preparing to unpack .../4-fonts-dejavu_2.37-8_all.deb ...
Unpacking fonts-dejavu (2.37-8) ...
Selecting previously unselected package fonts-noto-cjk.
Preparing to unpack .../5-fonts-noto-cjk_1%3a20230817+repack1-3_all.deb ...
Unpacking fonts-noto-cjk (1:20230817+repack1-3) ...
Selecting previously unselected package fonts-noto-cjk-extra.
Preparing to unpack .../6-fonts-noto-cjk-extra_1%3a20230817+repack1-3_all.deb ...
Unpacking fonts-noto-cjk-extra (1:20230817+repack1-3) ...
Setting up fonts-noto-cjk (1:20230817+repack1-3) ...
Setting up fonts-dejavu-mono (2.37-8) ...
Setting up fonts-dejavu-core (2.37-8) ...
Setting up fonts-croscore (20201225-2) ...
Setting up fonts-dejavu-extra (2.37-8) ...
Setting up fonts-noto-cjk-extra (1:20230817+repack1-3) ...
Setting up fonts-dejavu (2.37-8) ...
Processing triggers for fontconfig (2.15.0-1.1ubuntu2) ...
[custom-init] No custom files found, skipping...
[ls.io-init] done.
Obt-Message: Xinerama extension is not present on the server
```
6. I accessed my container through the web endpoint and confirmed that the CJK fonts were working correctly:
![image](https://github.com/user-attachments/assets/38b8463a-f4cf-4efc-bef2-0af444a9c9a5)
7. I then remade the changes on my `firefox-fonts-merge` branch, taking care to only include the actual changes and not the CI modifications I used for testing.


## Source / References:
#1007 
