### PR TITLE
Update the Opencl-Intel mod from 24.35.30872.22 to the latest fix 24.35.30872.32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   if [ -z "${MOD_VERSION}" ]; then \
     MOD_VERSION=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/latest" | jq -r '.tag_name'); \
   fi && \
-  COMP_RT_URLS_LEGACY1=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/tags/24.35.30872.22" | jq -r '.body' | grep wget | grep -v .sum | grep -v .ddeb | sed 's|wget ||g') && \
+  COMP_RT_URLS_LEGACY1=$(curl -sX GET "https://api.github.com/repos/intel/compute-runtime/releases/tags/24.35.30872.32" | jq -r '.body' | grep wget | grep -v .sum | grep -v .ddeb | sed 's|wget ||g') && \
   echo "**** grab legacy1 debs ****" && \
   mkdir -p /root-layer/opencl-intel-legacy1 && \
   for i in $COMP_RT_URLS_LEGACY1; do \


### PR DESCRIPTION
## Description:
There is that legacy 24.35 branch for legacy releases [which the last fix is that ](https://github.com/intel/compute-runtime/commits/releases/24.35/) which the latest fix is the 24.35.30872.32, so use that one istead of the 24.35.30872.22 current one.

## Benefits of this PR and context:
This is from the description of the 24.35 branch of the previous link which they say that at the end of the readme.file https://github.com/intel/compute-runtime/blob/master/LEGACY_PLATFORMS.md

## How Has This Been Tested?


## Source / References:
legacy description https://github.com/intel/compute-runtime/blob/master/LEGACY_PLATFORMS.md
24.35 legacy branch https://github.com/intel/compute-runtime/commits/releases/24.35/
https://github.com/intel/compute-runtime/releases/tag/24.35.30872.32
