### PR TITLE
Add Tinyauth as a valid auth check in swag-proxies.py

### DIFF
--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -13,6 +13,7 @@ AUTHELIA_REGEX = r"\n\s+include \/config\/nginx\/authelia-location\.conf;.*"
 AUTHENTIK_REGEX = r"\n\s+include \/config\/nginx\/authentik-location\.conf;.*"
 BASIC_AUTH_REGEX = r"\n\s+auth_basic.*"
 LDAP_REGEX = r"\n\s+include \/config\/nginx\/ldap-location\.conf;.*"
+TINYAUTH_REGEX = r"\n\s+include \/config\/nginx\/tinyauth-location\.conf;.*"
 
 
 def find_apps(fast=False):
@@ -50,6 +51,8 @@ def match_auth(auths, app, file_path, content):
         auths[app][file_path] = "Basic Auth"
     elif re.findall(LDAP_REGEX, content):
         auths[app][file_path] = "LDAP"
+    elif re.findall(TINYAUTH_REGEX, content):
+        auths[app][file_path] = "Tinyauth"
     else:
         auths[app][file_path] = "No Auth"
 


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
- Added support to check whether Tinyauth is used for application proxies in swag-proxies.py

## Benefits of this PR and context:
- It's a pretty simple PR and will help support the users who want to use Tinyauth (that also use swag + swag-dashboard).
- I could have made this into an issue, but I wanted to have my first FOSS contribution and it seemed like an easy problem to handle.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Found the problem by first configuring Tinyauth for firefox.subdomain.conf and checking my swag dashboard and seeing `No Auth`
- Resolved by finding the appropriate file that checks the `<auth>-location.conf` files
- Updated the file to include Tinyauth
- Confirmed that my swag dashboard now shows firefox as authenticated and when hovering `Tinyauth`


## Source / References:
- N/A
