### PR TITLE
mod-list.yml: add ipinfo

### DIFF
--- a/mod-list.yml
+++ b/mod-list.yml
@@ -151,6 +151,7 @@ mods:
       - geoip2influx: https://github.com/linuxserver/docker-mods/tree/swag-geoip2influx
       - imagemagick: https://github.com/linuxserver/docker-mods/tree/swag-imagemagick
       - ioncube: https://github.com/linuxserver/docker-mods/tree/swag-ioncube
+      - ipinfo: https://github.com/linuxserver/docker-mods/tree/swag-ipinfo
       - maxmind: https://github.com/linuxserver/docker-mods/tree/swag-maxmind
   transmission:
     mod_count: 5


### PR DESCRIPTION
Changing the count isn't needed due to <https://github.com/linuxserver/docker-mods/commit/7b711a5ce14c8b0db24d23556156bc7a61e695a7#diff-38b545ab93447d999e2b85222124cd0885e9cf503af55f582db3666081e23767L154>