### PR TITLE
swag_ondemand mod: Use swag_url label to construct default container urls, if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This mod gives SWAG the ability to start containers on-demand when accessed thro
 ![loading-page](.assets/loading-page.png)
 
 Instead of showing a 502 error page, it can display a loading page and auto-refresh once the container is up.
-  
+
 Add the following `include` to each proxy-conf where you wish to show the loading page inside the `server` section:
 ```nginx
 server {
@@ -68,7 +68,7 @@ Or set the following label if using `swag-auto-proxy`:
 ```
 ### Labels:
 - `swag_ondemand=enable` - required for on-demand.
-- `swag_ondemand_urls=https://wake.domain.com,https://app.domain.com/up` - *optional* - overrides the monitored URLs for starting the container on-demand. Defaults to `https://somecontainer.,http://somecontainer.`.
+- `swag_ondemand_urls=https://wake.domain.com,https://app.domain.com/up` - *optional* - overrides the monitored URLs for starting the container on-demand. Defaults to using the value of the `swag_url` label, if you've already set it for `swag-auto-proxy`, or `https://somecontainer.,http://somecontainer.` otherwise.
 
 ### URLs:
 - Accessed URLs need to start with one of `swag_ondemand_urls` to be matched, for example, setting `swag_ondemand_urls=https://plex.` will apply to `https://plex.domain.com` and `https://plex.domain.com/something`.

--- a/root/app/swag-ondemand.py
+++ b/root/app/swag-ondemand.py
@@ -49,7 +49,7 @@ class ContainerThread(threading.Thread):
             container_urls = container.labels.get("swag_ondemand_urls", f"https://{default_url},http://{default_url}")
             if container.name not in self.ondemand_containers.keys():
                 last_accessed = datetime.now()
-                logging.info(f"Started monitoring {container.name}")
+                logging.info(f"Started monitoring {container.name} for urls: {container_urls}")
             else:
                 last_accessed = self.ondemand_containers[container.name]["last_accessed"]
             self.ondemand_containers[container.name] = { "status": container.status, "urls": container_urls, "last_accessed": last_accessed }

--- a/root/app/swag-ondemand.py
+++ b/root/app/swag-ondemand.py
@@ -20,7 +20,7 @@ class ContainerThread(threading.Thread):
         self.daemon = True
         self.ondemand_containers = {}
         self.init_docker()
-            
+
     def init_docker(self):
         try:
             docker_host = os.environ.get("DOCKER_HOST", None)
@@ -52,6 +52,8 @@ class ContainerThread(threading.Thread):
                 logging.info(f"Started monitoring {container.name} for urls: {container_urls}")
             else:
                 last_accessed = self.ondemand_containers[container.name]["last_accessed"]
+                if container_urls != self.ondemand_containers["urls"]:
+                    logging.info(f"Updated urls for {container.name} to: {container_urls}")
             self.ondemand_containers[container.name] = { "status": container.status, "urls": container_urls, "last_accessed": last_accessed }
 
     def stop_containers(self):

--- a/root/app/swag-ondemand.py
+++ b/root/app/swag-ondemand.py
@@ -52,7 +52,7 @@ class ContainerThread(threading.Thread):
                 logging.info(f"Started monitoring {container.name} for urls: {container_urls}")
             else:
                 last_accessed = self.ondemand_containers[container.name]["last_accessed"]
-                if container_urls != self.ondemand_containers["urls"]:
+                if container_urls != self.ondemand_containers[container.name]["urls"]:
                     logging.info(f"Updated urls for {container.name} to: {container_urls}")
             self.ondemand_containers[container.name] = { "status": container.status, "urls": container_urls, "last_accessed": last_accessed }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
When I was setting up `swag_ondemand`, it occurred to me that I'm basically duplicating the same information in the `swag_ondemand_urls` label that I've already set in `swag_url` label to make `swag_auto_proxy` so I figured it would make sense to do that automatically.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
It makes using `swag_ondemand` and `swag_auto_proxy` slightly simpler to use together, and they already work great together. Plus it eliminates one place you might forget to update if you change the url of a container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've manually tested it with all the containers I have swag_ondemand configured. I added logging so that it's clear what it's doing, and it's working for me with labels like this:
```
    container_name: openvscode-server
    labels:
      - swag=enable
      - swag_port=3000
      - swag_url=code.domain.net
      - swag_auth=authelia
      - swag_ondemand=enable
      - swag_server_custom_directive=include /config/nginx/ondemand.conf;
      - swag_location_custom_directive=error_page 502 = @waking_up;
```
## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
