### PR TITLE
Update BuildImage workflow for pull requests

### DIFF
--- a/.github/workflows/BuildImage.yml
+++ b/.github/workflows/BuildImage.yml
@@ -1,19 +1,15 @@
 name: Build Image
 
 on:
-  workflow_dispatch:
-    inputs:
-      mod_version:
-        type: string
-        required: false
+  pull_request_target:
 
 env:
-  MOD_VERSION: ${{ inputs.mod_version }}
-  GITHUB_REPO: "linuxserver/docker-mods" #don't modify
-  ENDPOINT: "linuxserver/mods" #don't modify
-  BASEIMAGE: "master"
-  MODNAME: "dummy"
-  MULTI_ARCH: "false" #set to false if not needed
+  GITHUB_REPO: "linuxserver/docker-mods"
+  ENDPOINT: "linuxserver/mods"
+  BASEIMAGE: "pr"
+  MODNAME: "build"
+  MULTI_ARCH: "true"
+  MOD_VERSION: ""
 
 jobs:
   set-vars:
@@ -27,3 +23,25 @@ jobs:
           echo "MODNAME=${{ env.MODNAME }}" >> $GITHUB_STEP_SUMMARY
           echo "MULTI_ARCH=${{ env.MULTI_ARCH }}" >> $GITHUB_STEP_SUMMARY
           echo "MOD_VERSION=${MOD_VERSION}" >> $GITHUB_STEP_SUMMARY
+    outputs:
+      GITHUB_REPO: ${{ steps.outputs.outputs.GITHUB_REPO }}
+      ENDPOINT: ${{ steps.outputs.outputs.ENDPOINT }}
+      BASEIMAGE: ${{ steps.outputs.outputs.BASEIMAGE }}
+      MODNAME: ${{ steps.outputs.outputs.MODNAME }}
+      MOD_VERSION: ${{ steps.outputs.outputs.MOD_VERSION }}
+
+  build:
+    if: github.base_ref != 'refs/heads/master'
+    uses: linuxserver/github-workflows/.github/workflows/docker-mod-builder.yml@v1
+    needs: set-vars
+    secrets:
+      CR_USER: ${{ secrets.CR_USER }}
+      CR_PAT: ${{ secrets.CR_PAT }}
+      DOCKERUSER: ${{ secrets.DOCKERUSER }}
+      DOCKERPASS: ${{ secrets.DOCKERPASS }}
+    with:
+      GITHUB_REPO: ${{ needs.set-vars.outputs.GITHUB_REPO }}
+      ENDPOINT: ${{ needs.set-vars.outputs.ENDPOINT }}
+      BASEIMAGE: ${{ needs.set-vars.outputs.BASEIMAGE }}
+      MODNAME: ${{ needs.set-vars.outputs.MODNAME }}
+      MOD_VERSION: ${{ needs.set-vars.outputs.MOD_VERSION }}


### PR DESCRIPTION
Replace dummy workflow with one that only gets used for `pull_request_target` when PRs are made to other branches