### PR TITLE
fix: address ulimit exhaustion of user within swag-proxies.py

### DIFF
--- a/root/dashboard/swag-proxies.py
+++ b/root/dashboard/swag-proxies.py
@@ -4,6 +4,7 @@ import glob
 import json
 import os
 import re
+import resource
 import socket
 import sys
 import urllib3
@@ -69,12 +70,21 @@ def is_available(url):
     finally:
         s.close()
 
+def get_max_workers(default=50, reserve=10):
+    try:
+        max_procs, _ = resource.getrlimit(resource.RLIMIT_NPROC)
+        if max_procs == resource.RLIM_INFINITY:
+            return default
+        return max(1, min(default, max_procs - reserve))
+    except (AttributeError, ValueError, OSError):
+        return default
+
 
 urllib3.disable_warnings()
 fast = (len(sys.argv) > 1)
 apps, auths = find_apps(fast)
 discovered_apps = collections.defaultdict(dict)
-with concurrent.futures.ThreadPoolExecutor(max_workers=100) as executor:
+with concurrent.futures.ThreadPoolExecutor(max_workers=get_max_workers()) as executor:
     futures = {executor.submit(is_available, app): app for app in apps.keys()}
     for future in concurrent.futures.as_completed(futures):
         app = futures[future]


### PR DESCRIPTION
Proxies table briefly loads then disappears on full page load. This will dynamically assign max_workers based on resource.RLIMIT_NPROC

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Make /dashboard/swag-proxies.py dynamically assign its worker count based on the current process/thread limit:

- Added import resource.
- Added get_max_workers(default=50, reserve=10):
  - Queries resource.RLIMIT_NPROC.
  - Caps workers at min(default, max_procs - reserve).
  - Falls back to default if the limit cannot be read.
- Replaced the hardcoded max_workers=100 with max_workers=get_max_workers().

On the reported container (ulimit -u = 100) the script now uses min(50, 90) = 50 workers, leaving headroom for interpreter threads and avoiding the RuntimeError.

## Benefits of this PR and context:
proxies.php executes /dashboard/swag-proxies.py without the fast flag. That script created a ThreadPoolExecutor(max_workers=100). When a ulimit nproc of soft/hard of 100 is specified within compose this causes the hard coded max_workers of 100 to exceed the limits. 

RuntimeError: can't start new thread

The Python traceback was written to stdout, so PHP’s json_decode() received invalid JSON and returned null. proxies.php then iterated over null, producing an empty <tbody> and the PHP warning:

PHP Warning: foreach() argument must be of type array|object, null given in /dashboard/www/proxies.php on line 18

Because the AJAX call replaces the whole table on success, the initially rendered rows were overwritten with an empty table. 

## How Has This Been Tested?
Loaded in browser and SWAG instance with 21 proxies loads as expected now with ulimits: nproc: soft: 100 and hard: 100. 


## Source / References:
n/a
