### PR TITLE
Bundle lua-resty-string with mod due to broken Alpine deps in 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN \
   if ! tar -tzf /root-layer/crowdsec-nginx-bouncer.tgz >/dev/null 2>&1; then \
     echo "**** Invalid tarball, could not download crowdsec bouncer ****"; \
     exit 1; \
-  fi
+  fi && \
   apk add --no-cache build-base
   curl -sLo \
     /tmp/resty.tar.gz -L \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     echo "**** Invalid tarball, could not download crowdsec bouncer ****"; \
     exit 1; \
   fi && \
-  apk add --no-cache build-base
+  apk add --no-cache build-base && \
   curl -sLo \
     /tmp/resty.tar.gz -L \
     "https://github.com/openresty/lua-resty-string/archive/refs/tags/v0.15.tar.gz" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.21 AS buildstage
+FROM ghcr.io/linuxserver/baseimage-alpine:3.24 AS buildstage
 
 ARG MOD_VERSION
 
@@ -21,6 +21,14 @@ RUN \
     echo "**** Invalid tarball, could not download crowdsec bouncer ****"; \
     exit 1; \
   fi
+  apk add --no-cache build-base
+  curl -sLo \
+    /tmp/resty.tar.gz -L \
+    "https://github.com/openresty/lua-resty-string/archive/refs/tags/v0.15.tar.gz" && \
+  cd /tmp && \
+  tar -xzf ./resty.tar.gz && \
+  cd lua-resty-string-0.15 && \
+  make DESTDIR=/root-layer LUA_LIB_DIR="/usr/share/lua/common" install
 
 COPY root/ /root-layer/
 

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-swag-crowdsec/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-swag-crowdsec/run
@@ -23,7 +23,6 @@ echo "\
     lua5.1 \
     lua5.1-cjson \
     lua-resty-http \
-    lua-resty-string \
     lua-sec \
     nginx-mod-http-lua" >> /mod-repo-packages-to-install.list
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mods/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
For some reason lua-resty-string in Alpine 3.24 has changed from depending on `nginx-mod-http-lua` to depending on `openresty-mod-http-lua`, which means it can't be installed if nginx is. Thus far none of the other resty packages seem to be affected.

Instead we just pull and build the same version of lua-resty-string as Alpine, direct from the upstream repo and bundle it in the mod Dockerfile. Packaged version has been the same all the way back to 3.19 so should be backwards-compatible with older Swag images.

## Benefits of this PR and context:
Closes #1165 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
